### PR TITLE
1.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,17 @@ repositories {
 
 dependencies {
     //implementation 'org.iot-dsa:dslink-v2-websocket:+' //for a locally installed sdk
-    implementation 'com.github.iot-dsa-v2.sdk-dslink-java-v2:dslink-v2-websocket:+'
+    implementation 'com.github.iot-dsa-v2.sdk-dslink-java-v2:dslink-v2-websocket:v+'
     implementation 'commons-logging:commons-logging:+'
     implementation 'org.apache.commons:commons-lang3:3.6'
+    implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.cxf:cxf-rt-rs-security-oauth2:3.1.7'
     implementation 'org.apache.cxf:cxf-rt-rs-client:3.0.0-milestone1'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
     implementation 'javax.activation:activation:+'
+    
+    testImplementation 'junit:junit:+'
+    testImplementation 'org.mockito:mockito-all:+'
     
 }
 

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -15,6 +15,7 @@ Once you have a connection, you can set up a rule using the `Add Rule` action. T
 - Method: The REST method to use.
 - URL Parameters: A map of URL parameters to use when sending the REST request. If you want to use the value, timestamp, or status of an update in the params, use the placeholders `%VALUE%`, `%TIMESTAMP%` and `%STATUS%`.
 - Body: The body of the REST request, if applicable. Once again, use `%VALUE%`, `%TIMESTAMP%` and `%STATUS%` as placeholders.
+  - Note: If the REST API supports recieving multiple updates in one message, you can use `%STARTBLOCK%` and `%ENDBLOCK%` to denote the boundaries of a repeatable block. When needing to send many updates at once (in the case of having to catch up after a disconnect), the DSLink will repeat the block for each update and use commas to separate the blocks. Note that this will only work if all value, timestamp, and status placeholders are in the body and inside the repeatable block.
 - Minimum Refresh Rate: Optional, ensures that at least this many seconds elapse between updates. This means that the DSLink will suppress updates that are too close together. (Leave this parameter as 0 to not use this feature.)
 - Maximum Refresh Rate: Optional, ensures that an update gets sent every this many seconds. This means that if the DSA value updates too infrequently, the DSLink will send duplicate updates. (Leave this parameter as 0 to not use this feature.)
 ## Add a Rule Table
@@ -40,10 +41,12 @@ If you want to set up multiple rules in bulk, create a table of Rules in Atrius 
   },
   "data": {
     "<BuildingOS meter id>": [
+      %STARTBLOCK%
       [
         "%TIMESTAMP%",
         %VALUE%
       ]
+      %ENDBLOCK%
     ]
   }
 }
@@ -56,10 +59,12 @@ e.g:
   },
   "data": {
     "b9c7c0a03de611e895505254009e602c": [
+      %STARTBLOCK%
       [
         "%TIMESTAMP%",
         %VALUE%
       ]
+      %ENDBLOCK%
     ]
   }
 }

--- a/dslink.json
+++ b/dslink.json
@@ -1,6 +1,6 @@
 {
   "name": "dslink-java-v2-restadapter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Java DSA to REST adpater DSLink",
   "main": "bin/dslink-java-v2-restadapter",
   "configs": {

--- a/src/main/java/org/etsdb/ByteArrayBuilder.java
+++ b/src/main/java/org/etsdb/ByteArrayBuilder.java
@@ -1,0 +1,339 @@
+package org.etsdb;
+
+//import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.etsdb.impl.Input;
+import org.etsdb.impl.Utils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.BufferOverflowException;
+import java.nio.charset.Charset;
+
+/**
+ * A class that behaves much like a ByteBuffer, but automatically expands as required.
+ * <p>
+ * Put methods write values into the array at the current write offset, and update the write offset. Get methods read
+ * values at the current read offset, and update the read offset. Read methods read values at the current read offset
+ * but do not update the read offset.
+ *
+ * @author Matthew
+ */
+public class ByteArrayBuilder {
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+    private static final int DEFAULT_CAPACITY = 32;
+
+    private byte[] buffer;
+    private int writeOffset;
+    private int readOffset;
+
+    public ByteArrayBuilder() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    public ByteArrayBuilder(int initialSize) {
+        buffer = new byte[initialSize];
+    }
+
+//    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public ByteArrayBuilder(byte[] buffer) {
+        this.buffer = buffer;
+        this.writeOffset = buffer.length;
+    }
+
+    public void clear() {
+        writeOffset = 0;
+        readOffset = 0;
+    }
+
+//    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public byte[] getBuffer() {
+        return buffer;
+    }
+
+    public int getReadOffset() {
+        return readOffset;
+    }
+
+    public int getAvailable() {
+        return writeOffset - readOffset;
+    }
+
+    public void resetCapacity() {
+        if (buffer.length > DEFAULT_CAPACITY)
+            buffer = new byte[DEFAULT_CAPACITY];
+    }
+
+    //
+    // 
+    // Put
+    //
+    public void put(byte b) {
+        ensureCapacity(1);
+        buffer[writeOffset++] = b;
+    }
+
+    public void put(byte[] src) {
+        put(src, 0, src.length);
+    }
+
+    public void put(byte[] src, int offset, int length) {
+        ensureCapacity(length);
+        System.arraycopy(src, offset, buffer, writeOffset, length);
+        writeOffset += length;
+    }
+
+    public void putBoolean(boolean b) {
+        ensureCapacity(1);
+        buffer[writeOffset++] = (byte) (b ? 0x1 : 0x0);
+    }
+
+    public void putShort(short s) {
+        ensureCapacity(2);
+        buffer[writeOffset++] = (byte) (s >> 8);
+        buffer[writeOffset++] = (byte) s;
+    }
+
+    public void putInt(int i) {
+        ensureCapacity(4);
+        buffer[writeOffset++] = (byte) (i >> 24);
+        buffer[writeOffset++] = (byte) (i >> 16);
+        buffer[writeOffset++] = (byte) (i >> 8);
+        buffer[writeOffset++] = (byte) i;
+    }
+
+    public void putLong(long l) {
+        ensureCapacity(8);
+        buffer[writeOffset++] = (byte) (l >> 56);
+        buffer[writeOffset++] = (byte) (l >> 48);
+        buffer[writeOffset++] = (byte) (l >> 40);
+        buffer[writeOffset++] = (byte) (l >> 32);
+        buffer[writeOffset++] = (byte) (l >> 24);
+        buffer[writeOffset++] = (byte) (l >> 16);
+        buffer[writeOffset++] = (byte) (l >> 8);
+        buffer[writeOffset++] = (byte) l;
+    }
+
+    public void putFloat(float f) {
+        putInt(Float.floatToIntBits(f));
+    }
+
+    public void putDouble(double d) {
+        putLong(Double.doubleToLongBits(d));
+    }
+
+    /**
+     * String serialization with optimization for short strings.
+     *
+     * @param s String
+     */
+    public void putString(String s) {
+        byte[] bytes = null;
+        if (s != null)
+            bytes = s.getBytes(UTF8);
+
+        // Ensure necessary capacity for the string.
+        int ensureLength;
+        if (bytes == null)
+            ensureLength = 1;
+        else {
+            if (bytes.length >= 0x20000000)
+                throw new IllegalArgumentException("Value too big for compact int");
+            if (bytes.length >= 0x200000)
+                ensureLength = 4;
+            else if (bytes.length >= 0x2000)
+                ensureLength = 3;
+            else if (bytes.length >= 0x20)
+                ensureLength = 2;
+            else
+                ensureLength = 1;
+            ensureLength += bytes.length;
+        }
+        ensureCapacity(ensureLength);
+
+        // The first bit of the stored values determines if the string is null. The next two bits determine how many 
+        // bytes are used to store the string length. The rest of the value without these bits is the length.
+        // 100 = null.
+        // 011 = 4 bytes
+        // 010 = 3 bytes
+        // 001 = 2 bytes
+        // 000 = 1 byte
+        //
+        // This method is able to store string lengths up to 536870911 bytes.
+
+        if (bytes == null)
+            buffer[writeOffset++] = (byte) 0x80;
+        else {
+            if (bytes.length >= 0x200000) {
+                buffer[writeOffset++] = (byte) ((bytes.length >> 24) | 0x60);
+                buffer[writeOffset++] = (byte) (bytes.length >> 16);
+                buffer[writeOffset++] = (byte) (bytes.length >> 8);
+                buffer[writeOffset++] = (byte) bytes.length;
+            } else if (bytes.length >= 0x2000) {
+                buffer[writeOffset++] = (byte) ((bytes.length >> 16) | 0x40);
+                buffer[writeOffset++] = (byte) (bytes.length >> 8);
+                buffer[writeOffset++] = (byte) bytes.length;
+            } else if (bytes.length >= 0x20) {
+                buffer[writeOffset++] = (byte) ((bytes.length >> 8) | 0x20);
+                buffer[writeOffset++] = (byte) bytes.length;
+            } else
+                buffer[writeOffset++] = (byte) bytes.length;
+
+            // Write the actual string.
+            System.arraycopy(bytes, 0, buffer, writeOffset, bytes.length);
+            writeOffset += bytes.length;
+        }
+    }
+
+    public void put(Input in, int length) throws IOException {
+        ensureCapacity(length);
+        int done = 0;
+        while (done < length) {
+            int count;
+            try {
+                count = in.read(buffer, writeOffset + done, length - done);
+            } catch (IndexOutOfBoundsException e) {
+                throw new RuntimeException("buf: " + buffer.length + ", writeOffset=" + writeOffset + ", length="
+                        + length + ", done=" + done, e);
+            }
+            if (count == -1)
+                break;
+            done += count;
+        }
+        writeOffset += done;
+    }
+
+    //
+    // 
+    // Get
+    //
+    public byte get() {
+        ensureAvailable(1);
+        return buffer[readOffset++];
+    }
+
+    public int getByte() {
+        ensureAvailable(1);
+        return buffer[readOffset++] & 0xff;
+    }
+
+    public void get(byte[] dst) {
+        get(dst, 0, dst.length);
+    }
+
+    public void get(byte[] dst, int offset, int length) {
+        ensureAvailable(length);
+        System.arraycopy(buffer, readOffset, dst, offset, length);
+        readOffset += length;
+    }
+
+    public boolean getBoolean() {
+        ensureAvailable(1);
+        return !(buffer[readOffset++] == 0);
+    }
+
+    public short getShort() {
+        ensureAvailable(2);
+        return makeShort(buffer[readOffset++], buffer[readOffset++]);
+    }
+
+    public int getInt() {
+        ensureAvailable(4);
+        return makeInt(buffer[readOffset++], buffer[readOffset++], buffer[readOffset++], buffer[readOffset++]);
+    }
+
+    public long getLong() {
+        ensureAvailable(8);
+        return makeLong(buffer[readOffset++], buffer[readOffset++], buffer[readOffset++], buffer[readOffset++],
+                buffer[readOffset++], buffer[readOffset++], buffer[readOffset++], buffer[readOffset++]);
+    }
+
+    public float getFloat() {
+        return Float.intBitsToFloat(getInt());
+    }
+
+    public double getDouble() {
+        return Double.longBitsToDouble(getLong());
+    }
+
+    public String getString() {
+        // Get the length
+        byte b = get();
+
+        // Null?
+        if ((b & 0x80) == 0x80)
+            return null;
+
+        int length = 0;
+        if ((b & 0x60) == 0x60) {
+            ensureAvailable(3);
+            length |= (b & 0x1f) << 24;
+            length |= (buffer[readOffset++] & 0xff) << 16;
+            length |= (buffer[readOffset++] & 0xff) << 8;
+            length |= buffer[readOffset++] & 0xff;
+        } else if ((b & 0x40) == 0x40) {
+            ensureAvailable(2);
+            length |= (b & 0x1f) << 16;
+            length |= (buffer[readOffset++] & 0xff) << 8;
+            length |= buffer[readOffset++] & 0xff;
+        } else if ((b & 0x20) == 0x20) {
+            ensureAvailable(1);
+            length |= (b & 0x1f) << 8;
+            length |= buffer[readOffset++] & 0xff;
+        } else
+            length = b & 0xff;
+
+        ensureAvailable(length);
+        String s = new String(buffer, readOffset, length, UTF8);
+        readOffset += length;
+        return s;
+    }
+
+    public void get(OutputStream out, int length) throws IOException {
+        ensureAvailable(length);
+        out.write(buffer, readOffset, length);
+        readOffset += length;
+    }
+
+    //
+    //
+    // Private
+    //
+    private void ensureAvailable(int len) {
+        if (getAvailable() < len)
+            throw new BufferOverflowException();
+    }
+
+    private void ensureCapacity(int len) {
+        int min = writeOffset + len;
+        if (buffer.length < min) {
+            int newLength = buffer.length << 1;
+            while (newLength < min)
+                newLength <<= 1;
+            if (newLength > Utils.MAX_DATA_LENGTH)
+                throw new RuntimeException("Data length can not exceed " + Utils.MAX_DATA_LENGTH);
+            byte[] b = new byte[newLength];
+            System.arraycopy(buffer, 0, b, 0, buffer.length);
+            buffer = b;
+        }
+    }
+
+    private short makeShort(byte b1, byte b2) {
+        return (short) (((b1 & 0xff) << 8) | (b2 & 0xff));
+    }
+
+    private int makeInt(byte b1, byte b2, byte b3, byte b4) {
+        return ((b1 & 0xff) << 24) | ((b2 & 0xff) << 16) | ((b3 & 0xff) << 8) | (b4 & 0xff);
+    }
+
+    private long makeLong(byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7, byte b8) {
+        long l = (b1 & 0xffL) << 56;
+        l |= (b2 & 0xffL) << 48;
+        l |= (b3 & 0xffL) << 40;
+        l |= (b4 & 0xffL) << 32;
+        l |= (b5 & 0xffL) << 24;
+        l |= (b6 & 0xffL) << 16;
+        l |= (b7 & 0xffL) << 8;
+        l |= b8 & 0xffL;
+        return l;
+    }
+}

--- a/src/main/java/org/etsdb/ConfigException.java
+++ b/src/main/java/org/etsdb/ConfigException.java
@@ -1,0 +1,9 @@
+package org.etsdb;
+
+public class ConfigException extends EtsdbException {
+    private static final long serialVersionUID = 1L;
+
+    public ConfigException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/etsdb/Database.java
+++ b/src/main/java/org/etsdb/Database.java
@@ -1,0 +1,101 @@
+package org.etsdb;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.etsdb.util.Handler;
+
+/**
+ * TODO seriesIds must be valid file names. Consider adding code to convert invalid characters to something valid.
+ * TODO consider a flushing scheme that writes to files according to a set schedule, e.g. one file per second.
+ * TODO add a query that returns the given time range, plus the pvts immediately before and after the range. Currently
+ * this is three queries.
+ * <p>
+ * watch grep ^Cached /proc/meminfo # Page Cache size
+ * watch grep -A 1 dirty /proc/vmstat # Dirty Pages and writeback to disk activity
+ * watch cat /proc/sys/vm/nr_pdflush_threads # shows # of active pdflush threads
+ *
+ * @param <T> The type of value that is stored in the database. E.g. Double, Integer, DataValue,
+ *            MyArbitraryValueThatMightBeNumericOrTextOrArrayOrObject
+ * @author mlohbihler
+ */
+public interface Database<T> {
+    File getBaseDir();
+
+    void write(String seriesId, long ts, T value);
+
+    void query(String seriesId, long fromTs, long toTs, final QueryCallback<T> cb);
+
+    void query(String seriesId, long fromTs, long toTs, int limit, final QueryCallback<T> cb);
+
+    void query(String seriesId, long fromTs, long toTs, int limit, boolean reverse, final QueryCallback<T> cb);
+
+    long count(String seriesId, long fromTs, long toTs);
+
+    List<String> getSeriesIds();
+
+    long getDatabaseSize();
+
+    long availableSpace();
+
+    TimeRange getTimeRange(List<String> seriesIds);
+
+    long delete(String seriesId, long fromTs, long toTs);
+
+    void purge(String seriesId, long toTs);
+
+    /**
+     * @param seriesId Series to delete
+     */
+    void deleteSeries(String seriesId);
+
+    void close() throws IOException;
+
+    //
+    //
+    // Metrics
+    //
+    int getWritesPerSecond();
+
+    long getWriteCount();
+
+    void setWriteCountHandler(Handler<Long> handler);
+
+    long getFlushCount();
+
+    void setFlushCountHandler(Handler<Long> handler);
+
+    long getBackdateCount();
+
+    void setBackdateCountHandler(Handler<Long> handler);
+
+    int getOpenFiles();
+
+    void setOpenFilesHandler(Handler<Integer> handler);
+
+    long getFlushForced();
+
+    void setFlushForcedHandler(Handler<Long> handler);
+
+    long getFlushExpired();
+
+    void setFlushExpiredHandler(Handler<Long> handler);
+
+    long getFlushLimit();
+
+    void setFlushLimitHandler(Handler<Long> handler);
+
+    long getForcedClose();
+
+    int getLastFlushMillis();
+
+    void setLastFlushMillisHandler(Handler<Integer> handler);
+
+    int getQueueSize();
+
+    void setQueueSizeHandler(Handler<Integer> handler);
+
+    int getOpenShards();
+
+    void setOpenShardsHandler(Handler<Integer> handler);
+}

--- a/src/main/java/org/etsdb/DatabaseFactory.java
+++ b/src/main/java/org/etsdb/DatabaseFactory.java
@@ -1,0 +1,15 @@
+package org.etsdb;
+
+import org.etsdb.impl.DatabaseImpl;
+
+import java.io.File;
+
+public class DatabaseFactory {
+    public static <T> DatabaseImpl<T> createDatabase(File baseDir, Serializer<T> serializer) {
+        return createDatabase(baseDir, serializer, null);
+    }
+
+    public static <T> DatabaseImpl<T> createDatabase(File baseDir, Serializer<T> serializer, DbConfig config) {
+        return new DatabaseImpl<>(baseDir, serializer, config);
+    }
+}

--- a/src/main/java/org/etsdb/DbConfig.java
+++ b/src/main/java/org/etsdb/DbConfig.java
@@ -1,0 +1,235 @@
+package org.etsdb;
+
+import org.iot.dsa.logging.DSLogger;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("unused")
+public class DbConfig extends DSLogger {
+
+//    private static final Logger logger = LoggerFactory.getLogger(DbConfig.class);
+
+    private boolean addShutdownHook = true;
+    private boolean runCorruptionScan = true;
+    private boolean deleteEmptyDirs = true;
+    private int fileLockCheckInterval = 1000;
+    private int flushInterval = 1000 * 60 * 5;
+
+    /**
+     * If the shard has not been accessed within this time, it's output streams are closed. The flush process is what
+     * enacts this value, so the flush interval should best be equal to or less than this value.
+     */
+    private int shardStalePeriod = 1000 * 60 * 60;
+
+    private int maxOpenFiles = 500;
+    private boolean ignoreBackdates = false;
+    private int backdateStartDelay = 5000;
+
+    /**
+     * If true, writes will be queued in memory, and written out according to the queue parameters. If false, writes
+     * will be written directly to files in process.
+     */
+    private boolean useWriteQueue = false;
+
+    /**
+     * The minimum amount of time in milliseconds shard updates will be cached until they are written to disk by a run
+     * of the flush process.
+     */
+    private int queueExpireMinimum = 150000;
+
+    /**
+     * The maximum amount of time in milliseconds shard updates will be cached until they are written to disk by a run
+     * of the flush process.
+     */
+    private int queueExpireMaximum = 450000;
+
+    /**
+     * The minimum number of cached writes for a shard before they are written to disk by a run of the flush process.
+     * A number between the min and the max is chosen at random (if the values are different) which is used for the
+     * actual triggering of the flush.
+     */
+    private int queueShardQueueSizeMinimum = 25;
+
+    /**
+     * The maximum number of cached writes for a shard before they are written to disk by a run of the flush process.
+     * A number between the min and the max is chosen at random (if the values are different) which is used for the
+     * actual triggering of the flush.
+     */
+    private int queueShardQueueSizeMaximum = 25;
+
+    /**
+     * The maximum number of updates in the queue before they are written to disk by a run of the flush process.
+     */
+    private int queueMaxQueueSize = 100000;
+
+    /**
+     * Because all of the above parameters are only used during a run of the flush process, the actual queue size can
+     * exceed the maximum size. The discard queue size is checked with every write, and the given data is discarded
+     * if the
+     */
+    private int queueDiscardQueueSize = 1000000;
+
+    public void validate() throws ConfigException {
+        if (fileLockCheckInterval <= 0)
+            throw new ConfigException("fileLockCheckInterval must be greater than 0");
+
+        if (flushInterval <= 0)
+            throw new ConfigException("flushInterval must be greater than 0");
+
+        if (flushInterval < 300000) {
+            warn("Flush interval too low, setting it to 5 minutes (300000 ms)");
+            flushInterval = 300000;
+        }
+
+        if (shardStalePeriod < 0)
+            throw new ConfigException("shardStalePeriod cannot be negative");
+
+        if (backdateStartDelay < 0)
+            throw new ConfigException("backdateStartDelay cannot be negative");
+
+        if (useWriteQueue) {
+            if (queueExpireMinimum < 0)
+                throw new ConfigException("queueExpireMinimum cannot be negative");
+
+            if (queueExpireMaximum < queueExpireMinimum)
+                throw new ConfigException("queueExpireMaximum cannot be less than queueExpireMinimum");
+
+            if (queueShardQueueSizeMinimum <= 0)
+                throw new ConfigException("queueShardQueueSizeMinimum must be greater than 0 ");
+
+            if (queueMaxQueueSize < queueShardQueueSizeMinimum)
+                throw new ConfigException("queueMaxQueueSize must be greater than queueShardQueueSizeMinimum");
+
+            if (queueDiscardQueueSize < queueMaxQueueSize)
+                throw new ConfigException("queueDiscardQueueSize must be greater than queueMaxQueueSize");
+        }
+    }
+
+    public boolean isAddShutdownHook() {
+        return addShutdownHook;
+    }
+
+    public void setAddShutdownHook(boolean addShutdownHook) {
+        this.addShutdownHook = addShutdownHook;
+    }
+
+    public boolean isRunCorruptionScan() {
+        return runCorruptionScan;
+    }
+
+    public void setRunCorruptionScan(boolean runCorruptionScan) {
+        this.runCorruptionScan = runCorruptionScan;
+    }
+
+    public boolean isDeleteEmptyDirs() {
+        return deleteEmptyDirs;
+    }
+
+    public void setDeleteEmptyDirs(boolean deleteEmptyDirs) {
+        this.deleteEmptyDirs = deleteEmptyDirs;
+    }
+
+    public int getFileLockCheckInterval() {
+        return fileLockCheckInterval;
+    }
+
+    public void setFileLockCheckInterval(int fileLockCheckInterval) {
+        this.fileLockCheckInterval = fileLockCheckInterval;
+    }
+
+    public int getFlushInterval() {
+        return flushInterval;
+    }
+
+    public void setFlushInterval(int flushInterval) {
+        this.flushInterval = flushInterval;
+    }
+
+    public int getShardStalePeriod() {
+        return shardStalePeriod;
+    }
+
+    public void setShardStalePeriod(int shardStalePeriod) {
+        this.shardStalePeriod = shardStalePeriod;
+    }
+
+    public int getMaxOpenFiles() {
+        return maxOpenFiles;
+    }
+
+    public void setMaxOpenFiles(int maxOpenFiles) {
+        this.maxOpenFiles = maxOpenFiles;
+    }
+
+    public boolean isIgnoreBackdates() {
+        return ignoreBackdates;
+    }
+
+    public void setIgnoreBackdates(boolean ignoreBackdates) {
+        this.ignoreBackdates = ignoreBackdates;
+    }
+
+    public int getBackdateStartDelay() {
+        return backdateStartDelay;
+    }
+
+    public void setBackdateStartDelay(int backdateStartDelay) {
+        this.backdateStartDelay = backdateStartDelay;
+    }
+
+    public boolean isUseWriteQueue() {
+        return useWriteQueue;
+    }
+
+    public void setUseWriteQueue(boolean useWriteQueue) {
+        this.useWriteQueue = useWriteQueue;
+    }
+
+    public int getQueueExpireMinimum() {
+        return queueExpireMinimum;
+    }
+
+    public void setQueueExpireMinimum(int queueExpireMinimum) {
+        this.queueExpireMinimum = queueExpireMinimum;
+    }
+
+    public int getQueueExpireMaximum() {
+        return queueExpireMaximum;
+    }
+
+    public void setQueueExpireMaximum(int queueExpireMaximum) {
+        this.queueExpireMaximum = queueExpireMaximum;
+    }
+
+    public int getQueueShardQueueSizeMinimum() {
+        return queueShardQueueSizeMinimum;
+    }
+
+    public void setQueueShardQueueSizeMinimum(int queueShardQueueSizeMinimum) {
+        this.queueShardQueueSizeMinimum = queueShardQueueSizeMinimum;
+    }
+
+    public int getQueueShardQueueSizeMaximum() {
+        return queueShardQueueSizeMaximum;
+    }
+
+    public void setQueueShardQueueSizeMaximum(int queueShardQueueSizeMaximum) {
+        this.queueShardQueueSizeMaximum = queueShardQueueSizeMaximum;
+    }
+
+    public int getQueueMaxQueueSize() {
+        return queueMaxQueueSize;
+    }
+
+    public void setQueueMaxQueueSize(int queueMaxQueueSize) {
+        this.queueMaxQueueSize = queueMaxQueueSize;
+    }
+
+    public int getQueueDiscardQueueSize() {
+        return queueDiscardQueueSize;
+    }
+
+    public void setQueueDiscardQueueSize(int queueDiscardQueueSize) {
+        this.queueDiscardQueueSize = queueDiscardQueueSize;
+    }
+}

--- a/src/main/java/org/etsdb/EtsdbException.java
+++ b/src/main/java/org/etsdb/EtsdbException.java
@@ -1,0 +1,13 @@
+package org.etsdb;
+
+public class EtsdbException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public EtsdbException(String message) {
+        super(message);
+    }
+
+    public EtsdbException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/etsdb/QueryCallback.java
+++ b/src/main/java/org/etsdb/QueryCallback.java
@@ -1,0 +1,5 @@
+package org.etsdb;
+
+public interface QueryCallback<T> {
+    void sample(String seriesId, long ts, T value);
+}

--- a/src/main/java/org/etsdb/Serializer.java
+++ b/src/main/java/org/etsdb/Serializer.java
@@ -1,0 +1,7 @@
+package org.etsdb;
+
+abstract public class Serializer<T> {
+    abstract public void toByteArray(ByteArrayBuilder b, T obj, long ts);
+
+    abstract public T fromByteArray(ByteArrayBuilder b, long ts);
+}

--- a/src/main/java/org/etsdb/TimeRange.java
+++ b/src/main/java/org/etsdb/TimeRange.java
@@ -1,0 +1,58 @@
+package org.etsdb;
+
+import org.etsdb.impl.Utils;
+
+public class TimeRange {
+    private long from;
+    private long to;
+
+    public TimeRange() {
+        from = Long.MAX_VALUE;
+        to = -Long.MAX_VALUE;
+    }
+
+    public long getFrom() {
+        return from;
+    }
+
+    public void setFrom(long from) {
+        this.from = from;
+    }
+
+    public long getTo() {
+        return to;
+    }
+
+    public void setTo(long to) {
+        this.to = to;
+    }
+
+    public boolean isUndefined() {
+        return from == Long.MAX_VALUE;
+    }
+
+    public void add(long ts) {
+        if (from > ts)
+            from = ts;
+        if (to < ts)
+            to = ts;
+    }
+
+    public TimeRange union(TimeRange that) {
+        TimeRange result = new TimeRange();
+        result.setFrom(that.from < from ? that.from : from);
+        result.setTo(that.to > to ? that.to : to);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        if (isUndefined())
+            return "TimeRange [undefined]";
+        return "TimeRange [from=" +
+                Utils.prettyTimestamp(from) +
+                ", to=" +
+                Utils.prettyTimestamp(to) +
+                "]";
+    }
+}

--- a/src/main/java/org/etsdb/TypeOverrideTypes.java
+++ b/src/main/java/org/etsdb/TypeOverrideTypes.java
@@ -1,0 +1,59 @@
+package org.etsdb;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public enum TypeOverrideTypes {
+    MAP("map"),
+    NUMBER("number"),
+    STRING("string"),
+    DYNAMIC("dynamic"),
+    BOOL("bool"),
+    ENUM("enum"),
+    BINARY("binary"),
+    ARRAY("array"),
+    NONE("none");
+
+    private final String name;
+
+    TypeOverrideTypes(String name) {
+        this.name = name;
+    }
+
+    public static Set<String> buildEnums() {
+        Set<String> enums = new LinkedHashSet<>();
+        for (TypeOverrideTypes t : TypeOverrideTypes.values()) {
+            enums.add(t.getName());
+        }
+        return enums;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static TypeOverrideTypes fromName(String typeAsString) {
+        switch (typeAsString) {
+            case "map":
+                return MAP;
+            case "number":
+                return NUMBER;
+            case "string":
+                return STRING;
+            case "dynamic":
+                return DYNAMIC;
+            case "bool":
+                return BOOL;
+            case "enum":
+                return ENUM;
+            case "binary":
+                return BINARY;
+            case "array":
+                return ARRAY;
+            case "none":
+                return NONE;
+            default:
+                return NONE;
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/Backdate.java
+++ b/src/main/java/org/etsdb/impl/Backdate.java
@@ -1,0 +1,68 @@
+package org.etsdb.impl;
+
+import java.util.Arrays;
+
+/**
+ * A backdated sample that is unwritten.
+ *
+ * @author Matthew
+ */
+class Backdate implements Comparable<Backdate> {
+    private final String seriesId;
+    private final long shardId;
+    private final long offset;
+    private final byte[] data;
+
+    Backdate(String seriesId, long shardId, long offset, byte[] data, int off, int len) {
+        this.seriesId = seriesId;
+        this.shardId = shardId;
+        this.offset = offset;
+        this.data = Utils.copy(data, off, len);
+    }
+
+    String getSeriesId() {
+        return seriesId;
+    }
+
+    long getShardId() {
+        return shardId;
+    }
+
+    long getOffset() {
+        return offset;
+    }
+
+    byte[] getData() {
+        return data;
+    }
+
+    @Override
+    public int compareTo(Backdate that) {
+        return Utils.compareLong(offset, that.offset);
+    }
+
+    @Override
+    @SuppressWarnings("SimplifiableIfStatement")
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Backdate backdate = (Backdate) o;
+
+        if (getShardId() != backdate.getShardId()) return false;
+        if (getOffset() != backdate.getOffset()) return false;
+        if (getSeriesId() != null ? !getSeriesId().equals(backdate.getSeriesId()) : backdate.getSeriesId() != null)
+            return false;
+        return Arrays.equals(getData(), backdate.getData());
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getSeriesId() != null ? getSeriesId().hashCode() : 0;
+        result = 31 * result + (int) (getShardId() ^ (getShardId() >>> 32));
+        result = 31 * result + (int) (getOffset() ^ (getOffset() >>> 32));
+        result = 31 * result + (getData() != null ? Arrays.hashCode(getData()) : 0);
+        return result;
+    }
+}

--- a/src/main/java/org/etsdb/impl/Backdates.java
+++ b/src/main/java/org/etsdb/impl/Backdates.java
@@ -1,0 +1,124 @@
+package org.etsdb.impl;
+
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import org.iot.dsa.logging.DSLogger;
+
+/**
+ * A queue for writing backdated samples.
+ * <p>
+ *
+ * @author Matthew
+ */
+class Backdates extends DSLogger {
+
+//    static final Logger logger = LoggerFactory.getLogger(Backdates.class.getName());
+
+    final DatabaseImpl<?> db;
+    final int startDelay;
+    final List<Backdate> backdates = new LinkedList<>();
+
+    BackdatePoster poster;
+
+    Backdates(DatabaseImpl<?> db, int startDelay) {
+        this.db = db;
+        this.startDelay = startDelay;
+    }
+
+    void add(Backdate backdate) {
+        synchronized (backdates) {
+            backdates.add(backdate);
+            if (poster == null) {
+                poster = new BackdatePoster();
+            }
+        }
+    }
+
+    void close() {
+        BackdatePoster _poster;
+        synchronized (backdates) {
+            _poster = poster;
+        }
+
+        if (_poster != null) {
+            // Break the poster out of its start wait in case that's what it is doing.
+            _poster.notify();
+            _poster.join();
+        }
+    }
+
+    class BackdatePoster implements Runnable {
+
+        private final Thread thread;
+
+        BackdatePoster() {
+            thread = new Thread(this, "ETSDB Backdate Poster");
+            thread.setPriority(Thread.MAX_PRIORITY - 1);
+            thread.start();
+        }
+
+        @Override
+        public void run() {
+            try {
+                runImpl();
+            } catch (Exception e) {
+                warn("Backdate poster failed with exception", e);
+            }
+        }
+
+        private void runImpl() throws Exception {
+            if (startDelay > 0) {
+                synchronized (this) {
+                    wait(startDelay);
+                }
+            }
+
+            List<Backdate> shardInserts = new ArrayList<>();
+            while (true) {
+                Backdate first;
+
+                synchronized (backdates) {
+                    if (backdates.isEmpty()) {
+                        poster = null;
+                        break;
+                    }
+
+                    first = backdates.remove(0);
+                    shardInserts.add(first);
+
+                    // Collect all of the backdates for the same shard.
+                    Iterator<Backdate> iter = backdates.iterator();
+                    while (iter.hasNext()) {
+                        Backdate bd = iter.next();
+                        if (bd.getSeriesId().equals(first.getSeriesId()) && bd.getShardId() == first.getShardId()) {
+                            iter.remove();
+                            shardInserts.add(bd);
+                        }
+                    }
+                }
+
+                // Sort the shard inserts.
+                Collections.sort(shardInserts);
+
+                // Insert the backdates into the shard.
+                db.insert(first.getSeriesId(), first.getShardId(), shardInserts);
+
+                shardInserts.clear();
+            }
+
+            synchronized (backdates) {
+                poster = null;
+            }
+        }
+
+        void join() {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                // no op
+            }
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/BadRowException.java
+++ b/src/main/java/org/etsdb/impl/BadRowException.java
@@ -1,0 +1,11 @@
+package org.etsdb.impl;
+
+import java.io.IOException;
+
+public class BadRowException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    public BadRowException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/etsdb/impl/ChecksumDataInput.java
+++ b/src/main/java/org/etsdb/impl/ChecksumDataInput.java
@@ -1,0 +1,64 @@
+package org.etsdb.impl;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+class ChecksumDataInput implements ChecksumInput, Closeable {
+    private final RandomAccessFile delegate;
+
+    private byte sum;
+    private boolean eof;
+
+    ChecksumDataInput(RandomAccessFile delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean checkSum() throws IOException {
+        byte b = (byte) delegate.read();
+        boolean match = b == sum;
+        sum = 0;
+        return match;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (eof)
+            return -1;
+
+        int i = delegate.read();
+        sum += (byte) i;
+        if (i == -1)
+            eof = true;
+
+        return i;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (eof)
+            return -1;
+
+        int count = delegate.read(b, off, len);
+        if (count == -1) {
+            eof = true;
+            sum += (byte) -1;
+        } else {
+            for (int i = 0; i < count; i++)
+                sum += b[i + off];
+        }
+
+        return count;
+    }
+
+    @Override
+    public boolean isEof() {
+        return eof;
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/src/main/java/org/etsdb/impl/ChecksumInput.java
+++ b/src/main/java/org/etsdb/impl/ChecksumInput.java
@@ -1,0 +1,14 @@
+package org.etsdb.impl;
+
+import java.io.IOException;
+
+/**
+ * Required interface because we need to do checksums on records read from both input streams and random access files.
+ *
+ * @author Matthew
+ */
+interface ChecksumInput extends Input {
+    boolean checkSum() throws IOException;
+
+    boolean isEof();
+}

--- a/src/main/java/org/etsdb/impl/ChecksumInputStream.java
+++ b/src/main/java/org/etsdb/impl/ChecksumInputStream.java
@@ -1,0 +1,122 @@
+package org.etsdb.impl;
+
+import java.io.*;
+
+class ChecksumInputStream extends InputStream implements ChecksumInput {
+    private final InputStream delegate;
+
+    private byte sum;
+    private long position;
+    private boolean eof;
+
+    private long markPosition = -1;
+    private byte markSum;
+
+    ChecksumInputStream(File dataFile) {
+        if (dataFile.exists()) {
+            try {
+                this.delegate = new BufferedInputStream(new FileInputStream(dataFile));
+            } catch (FileNotFoundException e) {
+                // This should not happen because we just checked that the file exists.
+                throw new RuntimeException(e);
+            }
+        } else {
+            delegate = null;
+            eof = true;
+        }
+    }
+
+    @Override
+    public boolean checkSum() throws IOException {
+        if (eof)
+            return false;
+
+        byte b = (byte) delegate.read();
+        position++;
+        boolean match = b == sum;
+        sum = 0;
+        return match;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (eof)
+            return -1;
+
+        int i = delegate.read();
+        if (i == -1)
+            eof = true;
+        else {
+            position++;
+            sum += (byte) i;
+        }
+
+        return i;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (eof)
+            return -1;
+
+        int count = delegate.read(b, off, len);
+        if (count == -1)
+            eof = true;
+        else {
+            position += count;
+            for (int i = 0; i < count; i++)
+                sum += b[i + off];
+        }
+        return count;
+    }
+
+    long position() {
+        return position;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return delegate.available();
+    }
+
+    @Override
+    public boolean isEof() {
+        return eof;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return delegate.markSupported();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        delegate.mark(readlimit);
+        markPosition = position;
+        markSum = sum;
+        sum = 0;
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        delegate.reset();
+        if (markPosition != -1) {
+            position = markPosition;
+            sum = markSum;
+            markPosition = -1;
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long l = delegate.skip(n);
+        position += l;
+        return l;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (delegate != null)
+            delegate.close();
+    }
+}

--- a/src/main/java/org/etsdb/impl/ChecksumOutputStream.java
+++ b/src/main/java/org/etsdb/impl/ChecksumOutputStream.java
@@ -1,0 +1,47 @@
+package org.etsdb.impl;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+class ChecksumOutputStream extends OutputStream {
+    private final OutputStream delegate;
+
+    private byte sum;
+
+    ChecksumOutputStream(OutputStream delegate) {
+        if (delegate instanceof BufferedOutputStream) {
+            this.delegate = delegate;
+        } else {
+            this.delegate = new BufferedOutputStream(delegate, 128000); // 128 Kb
+        }
+    }
+
+    void writeSum() throws IOException {
+        delegate.write(sum);
+        sum = 0;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        sum += b;
+        delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        for (int i = 0; i < len; i++)
+            sum += b[i + off];
+        delegate.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/src/main/java/org/etsdb/impl/CorruptionScanner.java
+++ b/src/main/java/org/etsdb/impl/CorruptionScanner.java
@@ -1,0 +1,323 @@
+package org.etsdb.impl;
+
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.iot.dsa.logging.DSLogger;
+
+class CorruptionScanner extends DSLogger {
+
+//    private static final Logger logger = LoggerFactory.getLogger(CorruptionScanner.class.getName());
+
+    private final DatabaseImpl<?> db;
+
+    CorruptionScanner(DatabaseImpl<?> db) {
+        this.db = db;
+    }
+
+    public static void main(String[] args) throws IOException {
+        CorruptionScanner scanner = new CorruptionScanner(null);
+        File data = new File("corruption/1175.data");
+        long time = System.currentTimeMillis();
+        scanner.checkFile(data);
+        System.out.println("Time: " + (System.currentTimeMillis() - time));
+
+        for (int i = 101; i < 117; i++) {
+            data = new File("corruption/" + i + ".data");
+            scanner.checkFile(data);
+        }
+    }
+
+    void scan() throws IOException {
+        scan(db.getBaseDir());
+    }
+
+    private void scan(File parent) throws IOException {
+        File[] subdirs = parent.listFiles();
+        if (subdirs != null) {
+            for (File subdir : subdirs) {
+                File[] seriesDirs = subdir.listFiles();
+                if (seriesDirs != null) {
+                    for (File seriesDir : seriesDirs) {
+                        checkSeriesDir(seriesDir);
+                        deepScan(seriesDir);
+                    }
+                }
+            }
+        }
+    }
+
+    private void deepScan(File parent) throws IOException {
+        File[] subdirs = parent.listFiles();
+        if (subdirs != null) {
+            for (File subdir : subdirs) {
+                checkSeriesDir(subdir);
+                deepScan(subdir);
+            }
+        }
+    }
+
+    private void checkSeriesDir(File seriesDir) throws IOException {
+        if (!seriesDir.isDirectory()) {
+            return;
+        }
+        String seriesId = seriesDir.getName();
+
+        // temp files.
+        for (File temp : getFiles(seriesDir, ".temp")) {
+            long shardId = Utils.getShardId(temp.getName(), 10);
+            File data = new File(seriesDir, shardId + ".data");
+            File meta = new File(seriesDir, shardId + ".meta");
+
+            if (data.exists()) {
+                // If the data file exists, then just delete the file
+                warn("Found temp file " + temp + " with existing data file. Deleting.");
+                Utils.deleteWithRetry(temp);
+            } else if (meta.exists()) {
+                // If the meta file exists, then rename the temp file to data, and delete the meta file so that it gets
+                // recreated.
+                warn("Found temp file " + temp + " without data but with meta file. Moving.");
+                Utils.renameWithRetry(temp, data);
+                Utils.deleteWithRetry(meta);
+            } else if (temp.length() > 0) {
+                // A lonely temp file, but with content. Rename to data and see wht the corruption check has to say.
+                warn("Found temp file " + temp + " without data or meta file, with content. Moving.");
+                Utils.deleteWithRetry(temp);
+            } else {
+                // Otherwise, just delete the temp file.
+                warn("Found temp file " + temp + " without data, meta file, or content. Deleting.");
+                Utils.deleteWithRetry(temp);
+            }
+        }
+
+        // Ensure there is a meta file for every data file and vice versa.
+        List<File> datas = getFiles(seriesDir, ".data");
+        List<File> metas = getFiles(seriesDir, ".meta");
+
+        for (File data : datas) {
+            long shardId = Utils.getShardId(data.getName());
+            boolean found = false;
+            for (int i = metas.size() - 1; i >= 0; i--) {
+                File meta = metas.get(i);
+                if (Utils.getShardId(meta.getName()) == shardId) {
+                    metas.remove(i);
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                warn("Data file without meta file in series " + seriesId + ", shard " + shardId + ".");
+                // Don't need to recreate the meta file here. The
+                //                DataShard shard = new DataShard(seriesDir, seriesId, shardId);
+                //                shard.close();
+            }
+        }
+
+        // If there are any files left in the meta list, then they should just be deleted.
+        for (File meta : metas) {
+            warn("Meta file without data file at " + meta + ". Deleting file");
+            Utils.deleteWithRetry(meta);
+        }
+
+        // Check data files for corruption.
+        for (File data : datas) {
+            checkFile(data);
+        }
+    }
+
+    private List<File> getFiles(File dir, String suffix) {
+        List<File> result = new ArrayList<>();
+        File[] files = dir.listFiles(new SuffixFilter(suffix));
+        if (files != null) {
+            Collections.addAll(result, files);
+        }
+        return result;
+    }
+
+    private void checkFile(File data) throws IOException {
+        long position = 0;
+        // Start a detect/fix loop.
+        while (true) {
+            position = findCorruption(data, position);
+            if (position == -1) {
+                break;
+            }
+
+            // If any corruption was found, delete the meta file so that it gets recreated.
+            Utils.deleteWithRetry(new File(data.getParent(), Utils.getShardId(data.getName()) + ".meta"));
+
+            warn("Corruption detected in " + data + " at position " + position);
+            fixCorruption(data, position);
+        }
+    }
+
+    private long findCorruption(File data, long startPosition) throws IOException {
+        ChecksumInputStream in = null;
+        try {
+            ScanInfo scanInfo = new ScanInfo();
+            in = new ChecksumInputStream(data);
+
+            if (startPosition > 0) {
+                Utils.skip(in, startPosition);
+            }
+
+            while (true) {
+                long position = in.position();
+                if (!checkRow(in, scanInfo)) {
+                    return position;
+                }
+                if (scanInfo.isEof()) {
+                    break;
+                }
+            }
+        } finally {
+            Utils.closeQuietly(in);
+        }
+
+        return -1;
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void fixCorruption(File data, long badRowposition) throws IOException {
+        ChecksumInputStream in = null;
+        try {
+            ScanInfo scanInfo = new ScanInfo();
+            in = new ChecksumInputStream(data);
+            Utils.skip(in, badRowposition);
+
+            while (true) {
+                in.read();
+                in.mark(Utils.MAX_DATA_LENGTH + 10);
+                long position = in.position();
+                if (!checkRow(in, scanInfo)) {
+                    // Bad row. Keep looking for a good one.
+                    in.reset();
+                    continue;
+                } else if (scanInfo.isEof()) {
+                    // We reached the EOF before finding a good row. Splice off the end of the file.
+                    Utils.closeQuietly(in);
+                    cut(data, badRowposition, position);
+                    break;
+                }
+
+                // Now, look for another 2 to add confidence that it's for real.
+                if (!checkRow(in, scanInfo)) {
+                    // Bad row. The previous "good" one was probably just a fluke. Keep looking.
+                    in.reset();
+                    continue;
+                } else if (scanInfo.isEof()) {
+                    // We reached the EOF before finding a second good row. We'll assume the row is good and cut out
+                    // the bad bit.
+                    Utils.closeQuietly(in);
+                    cut(data, badRowposition, position);
+                    break;
+                }
+
+                // Found 2 good ones (or we're at EOF). Looking good...
+                if (!checkRow(in, scanInfo)) {
+                    // Oy. It's a stretch for there to be two false positives in a row, but we're going to call it a 
+                    // fluke and keep looking.
+                    in.reset();
+                    continue;
+                }
+
+                // Ok, good enough, or we're at the EOF. Either way, cut out the bad row and call it fixed.
+                Utils.closeQuietly(in);
+                cut(data, badRowposition, position);
+                break;
+            }
+        } finally {
+            Utils.closeQuietly(in);
+        }
+    }
+
+    private boolean checkRow(ChecksumInputStream in, ScanInfo scanInfo) throws IOException {
+        try {
+            DataShard._readSample(in, scanInfo);
+        } catch (BadRowException e) {
+            return false;
+        }
+
+        if (scanInfo.isEof()) // No row was read because we normally reached the EOF.
+        {
+            return true;
+        }
+
+        // ??? Check that the record's ts is greater than 0, greater than the last, and less than the shard max.
+        // Verify the checksum.
+        return in.checkSum();
+
+    }
+
+    /**
+     * Deletes bytes in a file
+     * <p>
+     *
+     * @param data the data file to splice
+     * @param from the inclusive position to delete from
+     * @param to   the exclusive position to delete to
+     * @throws IOException
+     */
+    private void cut(File data, long from, long to) throws IOException {
+        File temp = new File(data.getParentFile(), "temp");
+        FileInputStream in = null;
+        FileOutputStream out = null;
+
+        warn("Cutting corrupt data in " + data + " at " + from + ", length " + (to - from));
+
+        try {
+            in = new FileInputStream(data);
+            out = new FileOutputStream(temp);
+            byte[] buf = new byte[8192];
+
+            // Write to the from position.
+            copy(in, out, from, buf);
+
+            // Skip the difference in the input stream.
+            Utils.skip(in, to - from);
+
+            // Write the remainder of the input stream.
+            copy(in, out, data.length() - to, buf);
+        } finally {
+            Utils.closeQuietly(in);
+            Utils.closeQuietly(out);
+        }
+
+        Utils.deleteWithRetry(data);
+        Utils.renameWithRetry(temp, data);
+    }
+
+    private void copy(InputStream in, OutputStream out, long length, byte[] buf) throws IOException {
+        while (length > 0) {
+            int chunk = buf.length;
+            if (length < buf.length) {
+                chunk = (int) length;
+            }
+            int read = in.read(buf, 0, chunk);
+            if (read == -1) {
+                break;
+            }
+            out.write(buf, 0, read);
+            length -= read;
+        }
+    }
+
+    static class SuffixFilter implements FilenameFilter {
+
+        private final String suffix;
+
+        SuffixFilter(String suffix) {
+            this.suffix = suffix;
+        }
+
+        @Override
+        public boolean accept(File dir, String name) {
+            return name.endsWith(suffix);
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/DBProperties.java
+++ b/src/main/java/org/etsdb/impl/DBProperties.java
@@ -1,0 +1,67 @@
+package org.etsdb.impl;
+
+import org.etsdb.EtsdbException;
+import org.etsdb.util.AbstractProperties;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public class DBProperties extends AbstractProperties {
+    private static final String FILENAME = "db.properties";
+
+    private final DatabaseImpl<?> db;
+    private final Properties props;
+
+    public DBProperties(DatabaseImpl<?> db) {
+        this.db = db;
+        props = new Properties();
+
+        File file = getFile();
+        if (file.exists()) {
+            try {
+                FileInputStream in = new FileInputStream(file);
+                try {
+                    props.load(in);
+                } finally {
+                    Utils.closeQuietly(in);
+                }
+            } catch (IOException e) {
+                throw new EtsdbException(e);
+            }
+        }
+    }
+
+    @Override
+    protected String getStringImpl(String key) {
+        return props.getProperty(key);
+    }
+
+    public void setInt(String key, int value) {
+        setString(key, Integer.toString(value));
+    }
+
+    public void setBoolean(String key, boolean value) {
+        setString(key, Boolean.toString(value));
+    }
+
+    public void setString(String key, String value) {
+        props.setProperty(key, value);
+
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(getFile());
+            props.store(out, "");
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            Utils.closeQuietly(out);
+        }
+    }
+
+    File getFile() {
+        return new File(db.getBaseDir(), FILENAME);
+    }
+}

--- a/src/main/java/org/etsdb/impl/DataShard.java
+++ b/src/main/java/org/etsdb/impl/DataShard.java
@@ -1,0 +1,627 @@
+package org.etsdb.impl;
+
+import org.etsdb.ByteArrayBuilder;
+import org.iot.dsa.logging.DSLogger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+class DataShard extends DSLogger {
+    
+    private final DatabaseImpl<?> db;
+    private final String seriesId;
+    private final long shardId;
+    private final File dataFile;
+    private final File metaFile;
+
+    private final PendingWriteList cache;
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final AtomicInteger metaClosures = new AtomicInteger();
+    /**
+     * This field is the latest time in the data file *only*. There may be cache records with a later ts that this value does not represent.
+     */
+    private long latestTime = -Long.MAX_VALUE;
+    private MappedByteBuffer metaBuf;
+    private ChecksumOutputStream dataOut;
+    private long lastAccess;
+    private boolean closed;
+
+    DataShard(DatabaseImpl<?> db, File seriesDir, String seriesId, long shardId) throws IOException {
+        this.db = db;
+        this.seriesId = seriesId;
+        this.shardId = shardId;
+        metaFile = new File(seriesDir, shardId + ".meta");
+        dataFile = new File(seriesDir, shardId + ".data");
+
+        if (dataFile.exists() && !metaFile.exists()) {
+            recreateMetaFile();
+        }
+
+        cache = db.useQueue() ? new PendingWriteList(db.queueInfo) : null;
+
+        updateLastAccess();
+    }
+
+    static void _writeSample(ChecksumOutputStream out, long tsOffset, byte[] data, int offset, int length)
+            throws IOException {
+        out.write(Utils.SAMPLE_HEADER);
+        Utils.write4ByteUnsigned(out, tsOffset);
+        Utils.writeCompactInt(out, length);
+        out.write(data, offset, length);
+        out.writeSum();
+    }
+
+    static void _readSample(ChecksumInput in, ScanInfo scanInfo) throws IOException {
+        if (scanInfo.isEof()) {
+            // If we're done with the file, start iterating through the cache.
+            scanInfo.incrementCache();
+            return;
+        }
+
+        int b = in.read();
+        if (b == -1) {
+            // EOF
+            scanInfo.setEof(true);
+            return;
+        }
+
+        // Header
+        if (((byte) b) != Utils.SAMPLE_HEADER[0]) {
+            throw new BadRowException("Header error at 0: expected " + Utils.SAMPLE_HEADER[0] + ", got " + b);
+        }
+        for (int i = 1; i < Utils.SAMPLE_HEADER.length; i++) {
+            b = in.read();
+            if (((byte) b) != Utils.SAMPLE_HEADER[i]) {
+                throw new BadRowException("Header error at " + i + ": expected " + Utils.SAMPLE_HEADER[i] + ", got "
+                        + b);
+            }
+        }
+
+        // Offset
+        try {
+            scanInfo.setOffset(Utils.read4ByteUnsigned(in));
+        } catch (IOException e) {
+            throw new BadRowException("Offset error: IOException: " + e.getMessage());
+        }
+
+        // Length
+        int length;
+        try {
+            length = Utils.readCompactInt(in);
+        } catch (IOException e) {
+            throw new BadRowException("Length error: IOException: " + e.getMessage());
+        }
+        if (length < 0 || length > Utils.MAX_DATA_LENGTH) {
+            throw new BadRowException("Length error: cannot be negative or exceed " + Utils.MAX_DATA_LENGTH + ": "
+                    + length);
+        }
+
+        // Data
+        scanInfo.getData().clear();
+        scanInfo.getData().put(in, length);
+
+        if (in.isEof()) {
+            throw new BadRowException("EOF before row was completely read");
+        }
+    }
+
+    long getShardId() {
+        return shardId;
+    }
+
+    void lockRead() {
+        lock.readLock().lock();
+    }
+
+    void unlockRead() {
+        lock.readLock().unlock();
+    }
+
+    void lockWrite() {
+        lock.writeLock().lock();
+    }
+
+    void unlockWrite() {
+        lock.writeLock().unlock();
+    }
+
+    boolean isClosed() {
+        return closed;
+    }
+
+    List<PendingWrite> getCache() {
+        if (cache == null) {
+            return null;
+        }
+        return cache.getList();
+    }
+
+    int resetMetaClosures() {
+        return metaClosures.getAndSet(0);
+    }
+
+    void write(long ts, byte[] data, int off, int len) throws IOException {
+        if (closed) {
+            throw new IOException("DataShard already closed");
+        }
+
+        try {
+            ensureLatestTime();
+
+            long offset = Utils.getSampleOffset(ts);
+            if (ts >= latestTime) {
+                // Append
+                if (cache == null) {
+                    writeImmediate(ts, offset, data, off, len);
+                    db.flushCount.incrementAndGet();
+                    dataOut.flush();
+                } else {
+                    // First check if there are too many queued rows.
+                    if (db.queueInfo.queueSize.incrementAndGet() > db.queueInfo.discardQueueSize) {
+                        db.queueInfo.recentDiscards.incrementAndGet();
+                        db.queueInfo.queueSize.decrementAndGet();
+                    } else {
+                        cache.add(new PendingWrite(offset, data, off, len));
+                    }
+                }
+            } else {
+                trace("Backdate: seriesId=" + seriesId + ", ts=" + ts + ", latestTime=" + latestTime);
+                db.addBackdate(new Backdate(seriesId, shardId, offset, data, off, len));
+            }
+        } finally {
+            updateLastAccess();
+        }
+    }
+
+    private void writeImmediate(long ts, long offset, byte[] data, int off, int len) throws IOException {
+        openData();
+        openMeta();
+
+        _writeSample(dataOut, offset, data, off, len);
+        latestTime = ts;
+        metaBuf.putLong(latestTime);
+        metaBuf.flip();
+    }
+
+    int query(long fromOffset, long toOffset, int limit, RawQueryCallback cb) throws IOException {
+        if (closed) {
+            throw new IOException("DataShard already closed");
+        }
+
+        ChecksumInputStream in = null;
+        int count = 0;
+        try {
+            ScanInfo scanInfo = new ScanInfo(getCache());
+            in = new ChecksumInputStream(dataFile);
+
+            while (count < limit) {
+                readSample(in, scanInfo);
+                if (scanInfo.isEndOfShard()) {
+                    break;
+                }
+
+                if (scanInfo.getOffset() < fromOffset)
+                    continue; // Ignore. Before time range
+                else if (scanInfo.getOffset() >= toOffset) {
+                    break; // After time range. Done.
+                }
+                cb.sample(seriesId, Utils.getTimestamp(shardId, scanInfo.getOffset()), scanInfo.getData());
+                count++;
+            }
+        } finally {
+            Utils.closeQuietly(in);
+            updateLastAccess();
+        }
+
+        return count;
+    }
+
+    int queryReverse(long fromOffset, long toOffset, int limit, RawQueryCallback cb) throws IOException {
+        if (closed) {
+            throw new IOException("DataShard already closed");
+        }
+
+        int count = 0;
+        try {
+            ScanInfo scanInfo = new ScanInfo();
+
+            // Check the cache for eligible rows first.
+            if (cache != null) {
+                PendingWrite p;
+                for (int i = cache.getList().size() - 1; i >= 0; i--) {
+                    p = cache.getList().get(i);
+
+                    if (p.getOffset() >= toOffset)
+                        continue; // Ignore. After time range.
+                    else if (p.getOffset() < fromOffset) {
+                        // Before time range. Because cache rows are always after the file rows, we know that there
+                        // will be nothing of interest in the file. To prevent a file read, set the limit to 0.
+                        limit = 0;
+                        break;
+                    }
+                    // Found a cache row of interest. Use the scan info's builder in the callback.
+                    scanInfo.getData().clear();
+                    scanInfo.getData().put(p.getData());
+                    cb.sample(seriesId, Utils.getTimestamp(shardId, p.getOffset()), scanInfo.getData());
+                    count++;
+                }
+            }
+
+            // Check if we need to look at the file.
+            if (count < limit) {
+                // Yup. Read the file.
+                PositionQueue positions;
+                if (limit == Integer.MAX_VALUE) {
+                    positions = new PositionQueue(limit);
+                } else {
+                    positions = new PositionQueue(limit - count);
+                }
+
+                // Gather the positions of records in the time range in the shard.
+                ChecksumInputStream in = null;
+                try {
+                    in = new ChecksumInputStream(dataFile);
+                    while (true) {
+                        long position = in.position();
+                        readSample(in, scanInfo);
+
+                        if (scanInfo.isEof()) {
+                            break;
+                        }
+
+                        if (scanInfo.getOffset() < fromOffset)
+                            continue; // Ignore. Before time range
+                        else if (scanInfo.getOffset() >= toOffset) {
+                            break; // After time range. Done.
+                        }
+                        positions.push(position);
+                    }
+                } finally {
+                    Utils.closeQuietly(in);
+                }
+
+                // Use the found positions to retrieve the records in reverse.
+                if (positions.size() > 0) {
+                    RandomAccessFile raf = null;
+                    scanInfo.reset();
+                    try {
+                        raf = new RandomAccessFile(dataFile, "r");
+                        ChecksumDataInput craf = new ChecksumDataInput(raf);
+                        for (int i = positions.size() - 1; i >= 0; i--) {
+                            long position = positions.peek(i);
+                            raf.seek(position);
+                            readSample(craf, scanInfo);
+                            cb.sample(seriesId, Utils.getTimestamp(shardId, scanInfo.getOffset()), scanInfo.getData());
+                        }
+                        count += positions.size();
+                    } finally {
+                        Utils.closeQuietly(raf);
+                    }
+                }
+            }
+        } finally {
+            updateLastAccess();
+        }
+
+        return count;
+    }
+
+    long getMinTs() throws IOException {
+        if (!dataFile.exists()) {
+            if (cache == null || cache.isEmpty()) {
+                return Long.MIN_VALUE;
+            }
+            return Utils.getTimestamp(shardId, cache.getList().get(0).getOffset());
+        }
+
+        ChecksumInputStream in = null;
+        try {
+            if (closed) {
+                throw new IOException("DataShard already closed");
+            }
+
+            ScanInfo scanInfo = new ScanInfo();
+            in = new ChecksumInputStream(dataFile);
+
+            readSample(in, scanInfo);
+
+            if (scanInfo.isEndOfShard()) {
+                return Long.MAX_VALUE;
+            }
+            return Utils.getTimestamp(shardId, scanInfo.getOffset());
+        } finally {
+            Utils.closeQuietly(in);
+            updateLastAccess();
+        }
+    }
+
+    long getMaxTs() throws IOException {
+        if (cache == null || cache.isEmpty()) {
+            ensureLatestTime();
+            return latestTime;
+        }
+        PendingWrite p = cache.getList().get(cache.getList().size() - 1);
+        return Utils.getTimestamp(shardId, p.getOffset());
+    }
+
+    private void readSample(ChecksumInput in, ScanInfo scanInfo) throws IOException {
+        _readSample(in, scanInfo);
+        if (!scanInfo.isEof() && !in.checkSum()) {
+            throw new IOException("Corruption detected in " + dataFile.getPath());
+        }
+    }
+
+    long deleteSamples(long fromTs, long toTs) throws IOException {
+        if (!dataFile.exists()) {
+            return 0;
+        }
+
+        // Close the data output stream
+        closeData();
+
+        // Rewrite the file.
+        File tempFile = getTempFile();
+        ChecksumOutputStream tempOut = new ChecksumOutputStream(new FileOutputStream(tempFile, false));
+
+        ChecksumInputStream in = null;
+        ScanInfo scanInfo = new ScanInfo();
+        long deleteCount = 0;
+        try {
+            in = new ChecksumInputStream(dataFile);
+            ByteArrayBuilder b = scanInfo.getData();
+
+            readSample(in, scanInfo);
+
+            while (!scanInfo.isEof()) {
+                long offset = scanInfo.getOffset();
+                if (offset < fromTs || offset > toTs) {
+                    _writeSample(tempOut, scanInfo.getOffset(), b.getBuffer(), b.getReadOffset(), b.getAvailable());
+                } else {
+                    deleteCount++;
+                }
+                readSample(in, scanInfo);
+            }
+        } finally {
+            Utils.closeQuietly(in);
+            Utils.closeQuietly(tempOut);
+        }
+
+        // Delete the old file and copy the temp to replace it.
+        try {
+            Utils.deleteWithRetry(dataFile);
+        } finally {
+            Utils.renameWithRetry(tempFile, dataFile);
+        }
+        return deleteCount;
+    }
+
+    /**
+     * The list of backdates must be in chronological order.
+     */
+    void insertSamples(List<Backdate> backdates) throws IOException {
+        if (!dataFile.exists()) {
+            // This could happen if the shard was purged while the backdates were waiting to get written.
+            for (Backdate backdate : backdates) {
+                writeImmediate(Utils.getTimestamp(backdate.getShardId(), backdate.getOffset()), backdate.getOffset(),
+                        backdate.getData(), 0, backdate.getData().length);
+            }
+            db.flushCount.addAndGet(backdates.size());
+            dataOut.flush();
+            return;
+        }
+
+        // Close the data output stream
+        closeData();
+
+        // Rewrite the file.
+        File tempFile = getTempFile();
+        ChecksumOutputStream tempOut = new ChecksumOutputStream(new FileOutputStream(tempFile, false));
+
+        ChecksumInputStream in = null;
+        ScanInfo scanInfo = new ScanInfo();
+        try {
+            in = new ChecksumInputStream(dataFile);
+            ByteArrayBuilder b = scanInfo.getData();
+
+            Iterator<Backdate> iter = backdates.iterator();
+            Backdate next = iter.next();
+
+            readSample(in, scanInfo);
+
+            while (true) {
+                if (scanInfo.isEof() && next == null) // All done.
+                {
+                    break;
+                }
+
+                if (next == null || scanInfo.getOffset() < next.getOffset()) {
+                    // No more inserts, or the read sample is before the next insert. Write the current sample.
+                    _writeSample(tempOut, scanInfo.getOffset(), b.getBuffer(), b.getReadOffset(), b.getAvailable());
+                    readSample(in, scanInfo);
+                } else if (scanInfo.isEof() || scanInfo.getOffset() > next.getOffset()) {
+                    // No more samples, or the next is before the current. Write the next.
+                    _writeSample(tempOut, next.getOffset(), next.getData(), 0, next.getData().length);
+                    if (iter.hasNext()) {
+                        next = iter.next();
+                    } else {
+                        next = null;
+                    }
+                } else if (scanInfo.getOffset() == next.getOffset()) {
+                    // The sample and the next have the same timestamp. Overwrite with the next.
+                    _writeSample(tempOut, next.getOffset(), next.getData(), 0, next.getData().length);
+                    if (iter.hasNext()) {
+                        next = iter.next();
+                    } else {
+                        next = null;
+                    }
+                    readSample(in, scanInfo);
+                } else {
+                    throw new RuntimeException("Unhandled condition");
+                }
+            }
+        } finally {
+            Utils.closeQuietly(in);
+            Utils.closeQuietly(tempOut);
+        }
+
+        // Delete the old file and copy the temp to replace it.
+        try {
+            Utils.deleteWithRetry(dataFile);
+        } finally {
+            Utils.renameWithRetry(tempFile, dataFile);
+        }
+    }
+
+    void close() {
+        if (!closed) {
+            closed = true;
+
+            try {
+                writeCache();
+            } catch (IOException e) {
+                warn("Failed to write cache on close", e);
+            }
+
+            closeFiles();
+
+            try {
+                // Delete the temp file if it exists.
+                Utils.delete(getTempFile());
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+    }
+
+    void flush(long runtime, boolean force) throws IOException {
+        if (cache != null) {
+            if ((force && !cache.isEmpty()) || cache.expired(runtime) || cache.exceeds()) {
+                if (force) {
+                    db.flushForced.incrementAndGet();
+                } else if (cache.expired(runtime)) {
+                    db.flushExpired.incrementAndGet();
+                } else {
+                    db.flushLimit.incrementAndGet();
+                }
+                writeCache();
+            }
+        }
+
+        if (lastAccess < runtime - db.shardStalePeriod && (cache == null || cache.isEmpty())) {
+            close();
+        }
+    }
+
+    private void writeCache() throws IOException {
+        if (cache != null && !cache.isEmpty()) {
+            for (PendingWrite p : cache.getList()) {
+                writeImmediate(Utils.getTimestamp(shardId, p.getOffset()), p.getOffset(), p.getData(), 0,
+                        p.getData().length);
+            }
+            dataOut.flush();
+            db.queueInfo.queueSize.addAndGet(-cache.getList().size());
+            db.flushCount.addAndGet(cache.getList().size());
+            cache.clear();
+            closeFiles();
+        }
+    }
+
+    private void openData() throws IOException {
+        if (dataOut == null) {
+            if (!dataFile.getParentFile().exists()) {
+                if (!dataFile.getParentFile().mkdirs()) {
+                    String path = dataFile.getParent();
+                    error("Failed to create dataFile: " + path);
+                }
+            }
+            dataOut = new ChecksumOutputStream(new FileOutputStream(dataFile, dataFile.exists()));
+            db.openFiles.incrementAndGet();
+        }
+    }
+
+    private void openMeta() throws IOException {
+        if (metaBuf == null) {
+            RandomAccessFile raf = new RandomAccessFile(metaFile, "rw");
+            metaBuf = raf.getChannel().map(MapMode.READ_WRITE, 0, 8);
+            Utils.closeQuietly(raf);
+            db.openFiles.incrementAndGet();
+        }
+    }
+
+    void closeFiles() {
+        closeData();
+        closeMeta();
+    }
+
+    private void closeData() {
+        if (dataOut != null) {
+            Utils.closeQuietly(dataOut);
+            dataOut = null;
+            db.openFiles.decrementAndGet();
+        }
+    }
+
+    private void closeMeta() {
+        if (metaBuf != null) {
+            // The file is actually closed when the buffer is GC'ed.
+            metaBuf = null;
+            metaClosures.incrementAndGet();
+        }
+    }
+
+    //
+    //
+    // Private
+    //
+    private void updateLastAccess() {
+        lastAccess = System.currentTimeMillis();
+    }
+
+    private File getTempFile() {
+        return new File(dataFile.getParentFile(), dataFile.getName() + ".temp");
+    }
+
+    private void recreateMetaFile() throws IOException {
+        final AtomicLong lastTs = new AtomicLong();
+        query(0, Long.MAX_VALUE, Integer.MAX_VALUE, new RawQueryCallback() {
+            @Override
+            public void sample(String seriesId, long ts, ByteArrayBuilder b) {
+                lastTs.set(ts);
+            }
+        });
+
+        ByteArrayBuilder b = new ByteArrayBuilder(8);
+        b.putLong(lastTs.get());
+
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(metaFile);
+            b.get(out, 8);
+        } finally {
+            Utils.closeQuietly(out);
+        }
+    }
+
+    private void ensureLatestTime() throws IOException {
+        // Get the latest time.
+        if (latestTime == -Long.MAX_VALUE && metaFile.exists()) {
+            try {
+                openMeta();
+                latestTime = metaBuf.getLong();
+            } finally {
+                closeMeta();
+            }
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/DatabaseImpl.java
+++ b/src/main/java/org/etsdb/impl/DatabaseImpl.java
@@ -1,0 +1,707 @@
+package org.etsdb.impl;
+
+//import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.etsdb.util.Handler;
+import org.etsdb.util.atomic.NotifyAtomicInteger;
+import org.etsdb.util.atomic.NotifyAtomicLong;
+import org.etsdb.*;
+import org.etsdb.util.DirectoryUtils;
+import org.etsdb.util.EventHistogram;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+import org.iot.dsa.logging.DSLogger;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ *
+ * @param <T> the class of data that is written to this database.
+ * @author Matthew Lohbihler
+ */
+public class DatabaseImpl<T> extends DSLogger implements Database<T> {
+
+    public static final int VERSION = 2;
+//    static final Logger logger = LoggerFactory.getLogger(DatabaseImpl.class.getName());
+    final Serializer<T> serializer;
+    int shardStalePeriod;
+    // Open shards
+    int maxOpenFiles;
+    final NotifyAtomicInteger openShards = new NotifyAtomicInteger();
+    final NotifyAtomicInteger openFiles = new NotifyAtomicInteger();
+    // Write queue
+    WriteQueueInfo queueInfo;
+    final NotifyAtomicLong flushCount = new NotifyAtomicLong();
+    final AtomicLong forcedClose = new AtomicLong();
+    final NotifyAtomicLong flushForced = new NotifyAtomicLong();
+    final NotifyAtomicLong flushExpired = new NotifyAtomicLong();
+    final NotifyAtomicLong flushLimit = new NotifyAtomicLong();
+    // Configuration
+    private File baseDir;
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private Janitor janitor;
+    private final Map<String, Series<T>> seriesLookup = new HashMap<>();
+    // Backdates
+    private Backdates backdates;
+    // Monitors
+    private final EventHistogram writesPerSecond = new EventHistogram(5000, 2);
+    private final NotifyAtomicLong writeCount = new NotifyAtomicLong();
+    private final NotifyAtomicLong backdateCount = new NotifyAtomicLong();
+    // Runtime
+    private final DbConfig config;
+    private boolean closed;
+
+    public DatabaseImpl(File baseDir, Serializer<T> serializer, DbConfig config) {
+        if (config == null) // Use the defaults.
+        {
+            config = new DbConfig();
+        }
+        config.validate();
+        this.config = config;
+        this.serializer = serializer;
+        this.baseDir = baseDir;
+        open();
+    }
+
+    public void move(File newLoc) {
+        try {
+            close();
+        } catch (Exception ignored) {
+        }
+        lockExclusive();
+        try {
+            if (!this.baseDir.renameTo(newLoc)) {
+                throw new RuntimeException("Failed to move database");
+            }
+            this.baseDir = newLoc;
+        } catch (RuntimeException e) {
+            try {
+                close();
+            } catch (Exception ignored) {
+            }
+        } finally {
+            open();
+            unlockExclusive();
+        }
+    }
+
+    private void open() {
+        closed = false;
+        if (!baseDir.exists()) {
+            if (!baseDir.mkdirs()) {
+                error("Failed to create baseDir: " + baseDir.getParent());
+            }
+        }
+
+        info("Database started at " + baseDir.getAbsolutePath());
+
+        shardStalePeriod = config.getShardStalePeriod();
+        if (config.isIgnoreBackdates()) {
+            backdates = null;
+        } else {
+            backdates = new Backdates(this, config.getBackdateStartDelay());
+        }
+
+        queueInfo = config.isUseWriteQueue() ? new WriteQueueInfo(config) : null;
+
+        janitor = new Janitor(this);
+        janitor.lock();
+        janitor.setFileLockCheckInterval(config.getFileLockCheckInterval());
+        janitor.setFlushInterval(config.getFlushInterval());
+
+        if (config.isDeleteEmptyDirs()) {
+            // Clean up the file structure.
+            long start = System.currentTimeMillis();
+            Utils.deleteEmptyDirs(baseDir);
+            info("Empty dir delete took " + (System.currentTimeMillis() - start) + "ms");
+        }
+
+        DBProperties props = getProperties();
+        if (!props.getBoolean("clean", false)) {
+            if (config.isRunCorruptionScan()) {
+                try {
+                    long start = System.currentTimeMillis();
+                    new CorruptionScanner(this).scan();
+                    info("Corruption scan took " + (System.currentTimeMillis() - start) + "ms");
+                } catch (IOException e) {
+                    throw new EtsdbException(e);
+                }
+            }
+        } else {
+            if (config.isRunCorruptionScan()) {
+                info("Corruption scan skipped because the database is marked as clean");
+            }
+            props.setBoolean("clean", false);
+        }
+
+        if (config.isAddShutdownHook()) {
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        close();
+                    } catch (IOException e) {
+                        warn("Exception during close", e);
+                    }
+                }
+            });
+        }
+
+        maxOpenFiles = config.getMaxOpenFiles();
+
+        janitor.initiate();
+    }
+
+    @Override
+    public File getBaseDir() {
+        return baseDir;
+    }
+
+    private void lockConcurrent() {
+        lock.readLock().lock();
+    }
+
+    private void unlockConcurrent() {
+        lock.readLock().unlock();
+    }
+
+    private void lockExclusive() {
+        lock.writeLock().lock();
+    }
+
+    private void unlockExclusive() {
+        lock.writeLock().unlock();
+    }
+
+    public void renameSeries(File oldDir, String toId) {
+        lockConcurrent();
+        try {
+            File newDir = Utils.getSeriesDir(baseDir, toId);
+
+            if (!oldDir.exists()) // Old series name doesn't exist. Nothing to do.
+            {
+                return;
+            }
+
+            if (newDir.equals(oldDir)) // Same file. Nothing to do.
+            {
+                return;
+            }
+
+            if (newDir.exists()) {
+                throw new EtsdbException("New series name already exists");
+            }
+
+            if (!newDir.getParentFile().mkdirs()) {
+                String dir = newDir.getParent();
+                error("Failed to create directory: " + dir);
+            }
+            try {
+                Utils.renameWithRetry(oldDir, newDir);
+            } catch (IOException e) {
+                try {
+                    Utils.deleteWithRetry(newDir);
+                } catch (IOException e1) {
+                    // Ignore
+                }
+                throw new EtsdbException(e);
+            }
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    boolean tooManyFiles() {
+        return maxOpenFiles > 0 && openFiles.get() >= maxOpenFiles;
+    }
+
+    @Override
+    public void write(String seriesId, long ts, T value) {
+        lockConcurrent();
+        try {
+            writesPerSecond.hit();
+            writeCount.incrementAndGet();
+            try {
+                // Lock for read, because the write actually occurs at the shard, not the series. I.e. we can permit
+                // concurrent writes in a series.
+                Series<T> series = getSeries(seriesId);
+                series.write(ts, value);
+            } catch (IOException e) {
+                throw new EtsdbException(e);
+            }
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    @Override
+    public void query(String seriesId, long fromTs, long toTs, final QueryCallback<T> cb) {
+        query(seriesId, fromTs, toTs, Integer.MAX_VALUE, false, cb);
+    }
+
+    @Override
+    public void query(String seriesId, long fromTs, long toTs, int limit, final QueryCallback<T> cb) {
+        query(seriesId, fromTs, toTs, limit, false, cb);
+    }
+
+    @Override
+    public void query(String seriesId, long fromTs, long toTs, int limit, boolean reverse, final QueryCallback<T> cb) {
+        lockConcurrent();
+        try {
+            Series<T> series = getSeries(seriesId);
+            series.query(fromTs, toTs, limit, reverse, new CallbackWrapper(cb));
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    @Override
+    public long count(String seriesId, long fromTs, long toTs) {
+        lockConcurrent();
+        try {
+            final AtomicLong count = new AtomicLong();
+            Series<T> series = getSeries(seriesId);
+            series.query(fromTs, toTs, Integer.MAX_VALUE, false, new RawQueryCallback() {
+                @Override
+                public void sample(String seriesId, long ts, ByteArrayBuilder b) {
+                    count.incrementAndGet();
+                }
+            });
+            return count.get();
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    @Override
+    public List<String> getSeriesIds() {
+        lockConcurrent();
+        try {
+            List<String> ids = new ArrayList<>();
+
+            File[] base = baseDir.listFiles();
+            if (base != null) {
+                for (File sub : base) {
+                    if (sub.isDirectory()) {
+                        int subPos = sub.getPath().length() + 1;
+                        ids.addAll(list(sub, subPos));
+                    }
+                }
+            }
+
+            Collections.sort(ids);
+            return ids;
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    private Set<String> list(File start, int subPos) {
+        Set<String> filesList = new HashSet<>();
+        File[] files = start.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (f.isDirectory()) {
+                    filesList.addAll(list(f, subPos));
+                } else {
+                    String name = f.getName();
+                    if (name.endsWith(".data")) {
+                        filesList.add(f.getParent().substring(subPos));
+                    }
+                }
+            }
+        }
+        return filesList;
+    }
+
+    @Override
+    public long getDatabaseSize() {
+        return DirectoryUtils.getSize(baseDir).getSize();
+    }
+
+    @Override
+    public long availableSpace() {
+        return baseDir.getUsableSpace();
+    }
+
+    @Override
+    public TimeRange getTimeRange(List<String> seriesIds) {
+        lockConcurrent();
+        try {
+            TimeRange range = null;
+            for (String id : seriesIds) {
+                Series<T> series = getSeries(id);
+                TimeRange tr = series.getTimeRange();
+                if (range == null) {
+                    range = tr;
+                } else if (tr != null) {
+                    range = range.union(tr);
+                }
+            }
+            return range;
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    @Override
+    public long delete(String seriesId, long fromTs, long toTs) {
+        lockConcurrent();
+        try {
+            Series<T> series = getSeries(seriesId);
+            return series.delete(fromTs, toTs);
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    @Override
+    public void purge(String seriesId, long toTs) {
+        lockConcurrent();
+        try {
+            Series<T> series = getSeries(seriesId);
+            series.purge(toTs);
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    /**
+     * @param seriesId ID to remove
+     */
+    @Override
+    public void deleteSeries(String seriesId) {
+        lockExclusive();
+        try {
+            synchronized (seriesLookup) {
+                purge(seriesId, Long.MAX_VALUE);
+
+                File seriesDir = Utils.getSeriesDir(baseDir, seriesId);
+                try {
+                    Utils.delete(seriesDir);
+                } catch (IOException e) {
+                    warn("Error while deleting series " + seriesId, e);
+                }
+            }
+        } finally {
+            unlockExclusive();
+        }
+    }
+
+    @Override
+//    @SuppressFBWarnings("DM_GC")
+    public void close() throws IOException {
+        lockExclusive();
+        try {
+            if (!closed) {
+                if (backdates != null) {
+                    try {
+                        backdates.close();
+                    } catch (Exception ignored) {
+                    }
+                }
+
+                closed = true;
+
+                janitor.terminate();
+                janitor.join();
+
+                flush(true);
+
+                for (Series<T> series : getSerieses()) {
+                    series.close();
+                }
+
+                System.gc();
+
+                // Write a clean indicator into the database properties, so
+                // that we know a corruption check isn't necessary upon next
+                // start.
+                getProperties().setBoolean("clean", true);
+            }
+        } finally {
+            unlockExclusive();
+        }
+    }
+
+    private Series<T> getSeries(String seriesId) throws IOException {
+        if (closed) {
+            throw new IOException("Database is closed");
+        }
+
+        seriesId = sanitizeSeriesId(seriesId);
+        Series<T> series = seriesLookup.get(seriesId);
+        if (series == null) {
+            synchronized (seriesLookup) {
+                series = seriesLookup.get(seriesId);
+                if (series == null) {
+                    series = new Series<>(this, baseDir, seriesId, serializer);
+                    seriesLookup.put(seriesId, series);
+                }
+            }
+        }
+        return series;
+    }
+
+    private List<Series<T>> getSerieses() {
+        // serieses: plural for series my precious
+        List<Series<T>> serieses = new ArrayList<>();
+        synchronized (seriesLookup) {
+            serieses.addAll(seriesLookup.values());
+        }
+        return serieses;
+    }
+
+    public DBProperties getProperties() {
+        return new DBProperties(this);
+    }
+
+    //
+    //
+    // Backdates
+    //
+    void addBackdate(Backdate backdate) {
+        if (backdates != null) {
+            backdateCount.incrementAndGet();
+            backdates.add(backdate);
+        }
+    }
+
+    void insert(String seriesId, long shardId, List<Backdate> backdates) {
+        lockConcurrent();
+        try {
+            Series<T> series = getSeries(seriesId);
+            series.insert(shardId, backdates);
+        } catch (IOException e) {
+            throw new EtsdbException(e);
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    //
+    //
+    // Write queue
+    //
+    boolean useQueue() {
+        return queueInfo != null;
+    }
+
+    public int flush(boolean force) throws IOException {
+        lockConcurrent();
+        try {
+            int closures = 0;
+
+            long runtime = System.currentTimeMillis();
+            List<Series<T>> serieses = getSerieses();
+            for (Series<T> series : serieses) {
+                closures += series.flush(runtime, force);
+            }
+
+            // If the size of the queue still exceeds the max size, start force flushing random series until it doesn't.
+            if (useQueue()) {
+                if (queueInfo.queueSize.get() > queueInfo.maxQueueSize) {
+                    info("Max queue size exceeded. Writing lists to reduce.");
+                    while (!serieses.isEmpty()) {
+                        if (queueInfo.queueSize.get() <= queueInfo.maxQueueSize) {
+                            break;
+                        }
+
+                        int index = queueInfo.random.nextInt(serieses.size());
+                        Series<T> series = serieses.remove(index);
+                        closures += series.flush(runtime, true);
+                    }
+                }
+
+                int discards = queueInfo.recentDiscards.getAndSet(0);
+                if (discards > 0) {
+                    warn("Discarded " + discards + " writes");
+                }
+            }
+
+            return closures;
+        } finally {
+            unlockConcurrent();
+        }
+    }
+
+    //
+    //
+    // Monitors
+    //
+    @Override
+    public int getWritesPerSecond() {
+        return writesPerSecond.getEventCounts()[0] / 5;
+    }
+
+    @Override
+    public long getWriteCount() {
+        return writeCount.get();
+    }
+
+    public void setWriteCount(long count) {
+        writeCount.set(count);
+    }
+
+    @Override
+    public void setWriteCountHandler(Handler<Long> handler) {
+        writeCount.setHandler(handler);
+    }
+
+    @Override
+    public long getFlushCount() {
+        return flushCount.get();
+    }
+
+    public void setFlushCount(long val) {
+        flushCount.set(val);
+    }
+
+    @Override
+    public void setFlushCountHandler(Handler<Long> handler) {
+        flushCount.setHandler(handler);
+    }
+
+    @Override
+    public long getBackdateCount() {
+        return backdateCount.get();
+    }
+
+    public void setBackdateCount(long val) {
+        backdateCount.set(val);
+    }
+
+    @Override
+    public void setBackdateCountHandler(Handler<Long> handler) {
+        backdateCount.setHandler(handler);
+    }
+
+    @Override
+    public int getOpenFiles() {
+        return openFiles.get();
+    }
+
+    @Override
+    public void setOpenFilesHandler(Handler<Integer> handler) {
+        openFiles.setHandler(handler);
+    }
+
+    @Override
+    public long getFlushForced() {
+        return flushForced.get();
+    }
+
+    public void setFlushForced(long val) {
+        flushForced.set(val);
+    }
+
+    @Override
+    public void setFlushForcedHandler(Handler<Long> handler) {
+        flushForced.setHandler(handler);
+    }
+
+    @Override
+    public long getFlushExpired() {
+        return flushExpired.get();
+    }
+
+    public void setFlushExpired(long val) {
+        flushExpired.set(val);
+    }
+
+    @Override
+    public void setFlushExpiredHandler(Handler<Long> handler) {
+        flushExpired.setHandler(handler);
+    }
+
+    @Override
+    public long getFlushLimit() {
+        return flushLimit.get();
+    }
+
+    public void setFlushLimit(long val) {
+        flushLimit.set(val);
+    }
+
+    @Override
+    public void setFlushLimitHandler(Handler<Long> handler) {
+        flushLimit.setHandler(handler);
+    }
+
+    @Override
+    public long getForcedClose() {
+        return forcedClose.get();
+    }
+
+    @Override
+    public int getLastFlushMillis() {
+        return janitor.lastFlushMillis;
+    }
+
+    @Override
+    public void setLastFlushMillisHandler(Handler<Integer> handler) {
+        janitor.setFlushTimeHandler(handler);
+    }
+
+    @Override
+    public int getQueueSize() {
+        if (queueInfo == null) {
+            return 0;
+        }
+        return queueInfo.queueSize.get();
+    }
+
+    @Override
+    public void setQueueSizeHandler(Handler<Integer> handler) {
+        if (queueInfo != null) {
+            queueInfo.queueSize.setHandler(handler);
+        }
+    }
+
+    @Override
+    public int getOpenShards() {
+        return openShards.get();
+    }
+
+    @Override
+    public void setOpenShardsHandler(Handler<Integer> handler) {
+        openShards.setHandler(handler);
+    }
+
+    private String sanitizeSeriesId(String seriesId) {
+        if (seriesId.startsWith("/")) {
+            return seriesId.substring(1);
+        }
+        return seriesId;
+    }
+
+    class CallbackWrapper implements RawQueryCallback {
+
+        private final QueryCallback<T> cb;
+
+        public CallbackWrapper(QueryCallback<T> cb) {
+            this.cb = cb;
+        }
+
+        @Override
+        public void sample(String seriesId, long ts, ByteArrayBuilder b) {
+            T t = serializer.fromByteArray(b, ts);
+            if (t != null) {
+                cb.sample(seriesId, ts, t);
+            }
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/FileLock.java
+++ b/src/main/java/org/etsdb/impl/FileLock.java
@@ -1,0 +1,192 @@
+package org.etsdb.impl;
+
+import org.iot.dsa.logging.DSLogger;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Modified from the H2 FileLock implementation.
+ *
+ * @author Matthew
+ */
+public class FileLock  extends DSLogger {
+
+    private static final int SLEEP_GAP = 25;
+    private static final int TIME_GRANULARITY = 2000;
+    private final int sleep;
+    private File file;
+    /**
+     * The last time the lock file was written.
+     */
+    private long lastWrite;
+
+    private boolean locked;
+    private String uniqueId;
+
+    /**
+     * Create a new file locking object.
+     *
+     * @param db    Database implementation to use
+     * @param sleep the number of milliseconds to sleep
+     */
+    public FileLock(DatabaseImpl<?> db, int sleep) {
+        this.file = new File(db.getBaseDir(), ".lock.db");
+        this.sleep = sleep;
+    }
+
+    private static void sleep(int time) {
+        try {
+            Thread.sleep(time);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
+    }
+
+    /**
+     * Lock the file if possible. A file may only be locked once.
+     *
+     * @throws RuntimeException if locking was not successful
+     */
+    public synchronized void lock() {
+        if (locked)
+            throw new RuntimeException("already locked");
+        try {
+            lockFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Error locking file");
+        }
+        locked = true;
+    }
+
+    /**
+     * Unlock the file. The watchdog thread is stopped. This method does nothing
+     * if the file is already unlocked.
+     */
+    public synchronized void unlock() {
+        if (!locked)
+            return;
+
+        locked = false;
+        try {
+            if (file != null) {
+                if (load().equals(uniqueId)) {
+                    if (!file.delete()) {
+                        error("Failed to delete file: " + file.getPath());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            warn("FileLock.unlock", e);
+        } finally {
+            file = null;
+        }
+    }
+
+    /**
+     * Save the lock file.
+     */
+    public synchronized void save() {
+        try {
+            FileOutputStream out = null;
+            try {
+                out = new FileOutputStream(file);
+                out.write(uniqueId.getBytes("UTF-16"));
+            } finally {
+                Utils.closeQuietly(out);
+            }
+
+            lastWrite = file.lastModified();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not save properties " + file, e);
+        }
+    }
+
+    /**
+     * Load the properties file.
+     *
+     * @return the properties
+     */
+    public String load() {
+        FileInputStream in = null;
+        try {
+            synchronized (this) {
+                in = new FileInputStream(file);
+            }
+            byte[] b = new byte[128];
+            int position = 0;
+            int count;
+            while ((count = in.read(b, position, b.length - position)) != -1)
+                position += count;
+            return new String(b, 0, position, "UTF-16");
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load lock file", e);
+        } finally {
+            Utils.closeQuietly(in);
+        }
+    }
+
+    private void waitUntilOld() {
+        for (int i = 0; i < 2 * TIME_GRANULARITY / SLEEP_GAP; i++) {
+            long last;
+            synchronized (this) {
+                last = file.lastModified();
+            }
+            long dist = System.currentTimeMillis() - last;
+            if (dist < -TIME_GRANULARITY) {
+                // lock file modified in the future -
+                // wait for a bit longer than usual
+                sleep(2 * sleep);
+                return;
+            } else if (dist > TIME_GRANULARITY) {
+                return;
+            }
+            sleep(SLEEP_GAP);
+        }
+
+        throw new RuntimeException("Lock file recently modified");
+    }
+
+    private synchronized void setUniqueId() {
+        uniqueId = UUID.randomUUID().toString();
+    }
+
+    private synchronized void lockFile() throws IOException {
+        setUniqueId();
+        if (!file.createNewFile()) {
+            waitUntilOld();
+            save();
+            sleep(2 * sleep);
+            if (!load().equals(uniqueId))
+                throw new RuntimeException("Locked by another process");
+
+            if (!file.delete()) {
+                error("Failed to delete file: " + file.getPath());
+            }
+            if (!file.createNewFile())
+                throw new RuntimeException("Another process was faster");
+        }
+        save();
+        sleep(SLEEP_GAP);
+        if (!load().equals(uniqueId)) {
+            file = null;
+            throw new RuntimeException("Concurrent update");
+        }
+    }
+
+    public synchronized void update() {
+        if (file != null) {
+            // trace.debug("watchdog check");
+            try {
+                if (!file.exists() || file.lastModified() != lastWrite)
+                    save();
+            } catch (OutOfMemoryError e) {
+                // ignore
+            } catch (Exception e) {
+                warn("FileLock.run", e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/Input.java
+++ b/src/main/java/org/etsdb/impl/Input.java
@@ -1,0 +1,9 @@
+package org.etsdb.impl;
+
+import java.io.IOException;
+
+public interface Input {
+    int read() throws IOException;
+
+    int read(byte[] b, int off, int len) throws IOException;
+}

--- a/src/main/java/org/etsdb/impl/Janitor.java
+++ b/src/main/java/org/etsdb/impl/Janitor.java
@@ -1,0 +1,157 @@
+package org.etsdb.impl;
+
+import java.io.IOException;
+import org.etsdb.util.Handler;
+import org.iot.dsa.logging.DSLogger;
+
+
+class Janitor extends DSLogger implements Runnable {
+
+    private Handler<Integer> handler;
+    int lastFlushMillis;
+    private final DatabaseImpl<?> db;
+    private Thread thread;
+    private FileLock fileLock;
+    private int fileLockCheckInterval;
+    private int flushInterval;
+    private long nextFileLockCheck;
+    private long nextFlush;
+
+    /**
+     * The number of meta closures that have been done since the last GC.
+     */
+    private int fileClosures;
+
+    private volatile boolean running;
+
+    Janitor(DatabaseImpl<?> db) {
+        this.db = db;
+    }
+
+    void setFlushTimeHandler(Handler<Integer> handler) {
+        this.handler = handler;
+    }
+
+    void setFileLockCheckInterval(int fileLockCheckInterval) {
+        this.fileLockCheckInterval = fileLockCheckInterval;
+    }
+
+    void setFlushInterval(int flushInterval) {
+        this.flushInterval = flushInterval;
+    }
+
+    void lock() {
+        fileLock = new FileLock(db, fileLockCheckInterval);
+        fileLock.lock();
+    }
+
+    void initiate() {
+        long now = System.currentTimeMillis();
+        nextFileLockCheck = now + fileLockCheckInterval;
+        nextFlush = now + flushInterval;
+
+        running = true;
+
+        thread = new Thread(this, "ETSDB Maintenance");
+        //thread.setDaemon(true);
+        thread.setPriority(Thread.MAX_PRIORITY - 1);
+        thread.start();
+    }
+
+    void terminate() {
+        running = false;
+    }
+
+    @Override
+    public void run() {
+        while (running) {
+            try {
+                runImpl();
+            } catch (Exception e) {
+                error("Error during Janitor run", e);
+            }
+        }
+
+        fileLock.unlock();
+    }
+
+    private void runImpl() {
+        long next = nextFileLockCheck;
+        if (next > nextFlush)
+            next = nextFlush;
+
+        long sleep = next - System.currentTimeMillis();
+        if (sleep > 0) {
+            synchronized (this) {
+                if (running) {
+                    try {
+                        wait(sleep);
+                    } catch (InterruptedException e) {
+                        // Ignore
+                    }
+                }
+            }
+        }
+
+        if (!running)
+            return;
+
+        long now = System.currentTimeMillis();
+        if (now >= nextFileLockCheck) {
+            fileLock.update();
+            nextFileLockCheck = now + fileLockCheckInterval;
+        }
+
+        if (now >= nextFlush) {
+            long time = System.currentTimeMillis();
+            boolean gc = false;
+            try {
+                fileClosures += db.flush(false);
+
+                // A GC is required for the mapped buffers to be closed.
+                if (running) {
+                    if (db.tooManyFiles() || fileClosures > db.maxOpenFiles / 2) {
+                        trace("Running garbage collection. Files to close: " + fileClosures);
+                        System.gc();
+                        gc = true;
+                        db.openFiles.addAndGet(-fileClosures);
+                        fileClosures = 0;
+                    }
+                }
+            } catch (IOException e) {
+                error("Exception during scheduled flush", e);
+            }
+
+            time = System.currentTimeMillis() - time;
+            lastFlushMillis = (int) time;
+            Handler<Integer> handler = this.handler;
+            if (handler != null) {
+                handler.handle(lastFlushMillis);
+            }
+
+            trace("Write queue flush took " + time + " ms");
+            trace("write/s=" + db.getWritesPerSecond() + ", backdateCount=" + db.getBackdateCount()
+                    + ", writeCount=" + db.getWriteCount() + ", openFiles=" + db.getOpenFiles() + ", forcedClose="
+                    + db.getForcedClose());
+
+            // If the time that it took to do the last flush, times 10, is greater than the flush interval, use
+            // the time * 10 as the interval. This prevents the flush from running too often. But, don't let the 
+            // sleep time exceed the flush interval * 4.
+            time *= 10;
+
+            if (gc || time < flushInterval)
+                time = flushInterval;
+            else if (time > flushInterval * 4)
+                time = flushInterval * 4;
+            nextFlush = System.currentTimeMillis() + time;
+        }
+    }
+
+    void join() {
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            // Ignore
+        }
+    }
+}

--- a/src/main/java/org/etsdb/impl/PendingWrite.java
+++ b/src/main/java/org/etsdb/impl/PendingWrite.java
@@ -1,0 +1,49 @@
+package org.etsdb.impl;
+
+import java.util.Arrays;
+
+public class PendingWrite implements Comparable<PendingWrite> {
+    private final long offset;
+    private final byte[] data;
+
+    public PendingWrite(long offset, byte[] data, int off, int len) {
+        this(offset, Utils.copy(data, off, len));
+    }
+
+    public PendingWrite(long offset, byte[] data) {
+        this.offset = offset;
+        this.data = data != null ? data.clone() : null;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    @SuppressWarnings("SimplifiableIfStatement")
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PendingWrite that = (PendingWrite) o;
+        if (getOffset() != that.getOffset()) return false;
+        return Arrays.equals(data, that.data);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (getOffset() ^ (getOffset() >>> 32));
+        result = 31 * result + (data != null ? Arrays.hashCode(data) : 0);
+        return result;
+    }
+
+    public byte[] getData() {
+        return data != null ? data.clone() : null;
+    }
+
+    @Override
+    public int compareTo(PendingWrite that) {
+        return Utils.compareLong(offset, that.offset);
+    }
+}

--- a/src/main/java/org/etsdb/impl/PendingWriteList.java
+++ b/src/main/java/org/etsdb/impl/PendingWriteList.java
@@ -1,0 +1,59 @@
+package org.etsdb.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PendingWriteList {
+    private final WriteQueueInfo queueInfo;
+    private final List<PendingWrite> list = new ArrayList<>();
+    private long expiryTime;
+    private int maxSize;
+
+    public PendingWriteList(WriteQueueInfo queueInfo) {
+        this.queueInfo = queueInfo;
+    }
+
+    public boolean expired(long runtime) {
+        return expiryTime != 0 && expiryTime <= runtime;
+    }
+
+    public void add(PendingWrite sample) {
+        if (list.isEmpty()) {
+            expiryTime = queueInfo.getExpiryTime();
+            maxSize = queueInfo.getShardQueueSize();
+            list.add(sample);
+        } else {
+            // There is a possibility that this write is backdated compared to the list or is an overwrite, so do a 
+            // search to find its insert position.
+            int index = Collections.binarySearch(list, sample);
+            if (index < 0) {
+                index = -index - 1;
+                if (index == list.size())
+                    list.add(sample);
+                else
+                    list.add(index, sample);
+            } else
+                list.set(index, sample);
+        }
+    }
+
+    public void clear() {
+        if (!list.isEmpty()) {
+            list.clear();
+            expiryTime = 0;
+        }
+    }
+
+    public boolean exceeds() {
+        return list.size() > maxSize;
+    }
+
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    public List<PendingWrite> getList() {
+        return list;
+    }
+}

--- a/src/main/java/org/etsdb/impl/PositionQueue.java
+++ b/src/main/java/org/etsdb/impl/PositionQueue.java
@@ -1,0 +1,44 @@
+package org.etsdb.impl;
+
+import org.etsdb.util.queue.LongLimitQueue;
+import org.etsdb.util.queue.LongQueue;
+
+/**
+ * Remembers the positions of rows in shards to facilitate reverse queries. Limit queues are used to simplify limit
+ * queries.
+ *
+ * @author Matthew
+ */
+public class PositionQueue {
+    private final LongQueue queue;
+    private final LongLimitQueue limitQueue;
+
+    public PositionQueue(int limit) {
+        if (limit == Integer.MAX_VALUE) {
+            queue = new LongQueue();
+            limitQueue = null;
+        } else {
+            queue = null;
+            limitQueue = new LongLimitQueue(limit);
+        }
+    }
+
+    public void push(long l) {
+        if (queue != null)
+            queue.push(l);
+        else
+            limitQueue.push(l);
+    }
+
+    public int size() {
+        if (queue != null)
+            return queue.size();
+        return limitQueue.size();
+    }
+
+    public long peek(int index) {
+        if (queue != null)
+            return queue.peek(index);
+        return limitQueue.peek(index);
+    }
+}

--- a/src/main/java/org/etsdb/impl/RawQueryCallback.java
+++ b/src/main/java/org/etsdb/impl/RawQueryCallback.java
@@ -1,0 +1,7 @@
+package org.etsdb.impl;
+
+import org.etsdb.ByteArrayBuilder;
+
+public interface RawQueryCallback {
+    void sample(String seriesId, long ts, ByteArrayBuilder b);
+}

--- a/src/main/java/org/etsdb/impl/ScanInfo.java
+++ b/src/main/java/org/etsdb/impl/ScanInfo.java
@@ -1,0 +1,93 @@
+package org.etsdb.impl;
+
+import org.etsdb.ByteArrayBuilder;
+
+import java.util.List;
+
+/**
+ * Reusable object for efficiently handling queries.
+ *
+ * @author Matthew
+ */
+class ScanInfo {
+    /**
+     * The time offset of the current record
+     */
+    private long offset;
+    /**
+     * The data for the current record
+     */
+    private ByteArrayBuilder data = new ByteArrayBuilder(1024);
+    /**
+     * The pointer to the next cache record.
+     */
+    private int cacheIndex;
+    /**
+     * The shard's pending write cache.
+     */
+    private List<PendingWrite> cache;
+    /**
+     * If true, the end of file was reached, and scan should be ended. The offset and data fields should not be used.
+     */
+    private boolean eof;
+
+    public ScanInfo() {
+        // no op
+    }
+
+    public ScanInfo(List<PendingWrite> cache) {
+        this.cache = cache;
+        cacheIndex = -1;
+    }
+
+    long getOffset() {
+        return offset;
+    }
+
+    void setOffset(long offset) {
+        this.offset = offset;
+    }
+
+    ByteArrayBuilder getData() {
+        return data;
+    }
+
+    void setData(ByteArrayBuilder data) {
+        this.data = data;
+    }
+
+    boolean isEndOfShard() {
+        if (eof && cache != null)
+            return cacheIndex >= cache.size();
+        return eof;
+    }
+
+    boolean isEof() {
+        return eof;
+    }
+
+    void setEof(boolean eof) {
+        this.eof = eof;
+        incrementCache();
+    }
+
+    void incrementCache() {
+        if (cache != null && ++cacheIndex < cache.size()) {
+            PendingWrite p = cache.get(cacheIndex);
+            offset = p.getOffset();
+            data.clear();
+            data.put(p.getData());
+        }
+    }
+
+    void reset() {
+        reset(null);
+    }
+
+    void reset(DataShard shard) {
+        this.eof = false;
+        cacheIndex = -1;
+        if (shard != null)
+            cache = shard.getCache();
+    }
+}

--- a/src/main/java/org/etsdb/impl/Series.java
+++ b/src/main/java/org/etsdb/impl/Series.java
@@ -1,0 +1,351 @@
+package org.etsdb.impl;
+
+import org.etsdb.ByteArrayBuilder;
+import org.etsdb.Serializer;
+import org.etsdb.TimeRange;
+import org.iot.dsa.logging.DSLogger;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class Series<T> extends DSLogger {
+    private final DatabaseImpl<T> db;
+    private final File seriesDir;
+    private final String id;
+    private final Serializer<T> serializer;
+
+    private final ByteArrayBuilder buffer = new ByteArrayBuilder();
+    private final Map<Long, DataShard> shardLookup = new HashMap<>();
+    private long minShard = Long.MAX_VALUE;
+    private long maxShard = 0;
+
+    Series(DatabaseImpl<T> db, File baseDir, String id, Serializer<T> serializer) {
+        this.db = db;
+        seriesDir = Utils.getSeriesDir(baseDir, id);
+        if (!(seriesDir.exists() || seriesDir.mkdirs())) {
+            error("Failed to create seriesDir: " + seriesDir.getPath());
+        }
+        this.id = id;
+        this.serializer = serializer;
+
+        String[] shards = seriesDir.list(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".data") || name.endsWith(".meta");
+            }
+        });
+        if (shards != null) {
+            for (String shard : shards) {
+                try {
+                    // Remove the .data extension
+                    shard = shard.substring(0, shard.length() - 5);
+                    updateMinMax(Long.parseLong(shard));
+                } catch (NumberFormatException e) {
+                    // no op
+                }
+            }
+        }
+    }
+
+    String getId() {
+        return id;
+    }
+
+    void write(long ts, T value) throws IOException {
+        synchronized (buffer) {
+            buffer.clear();
+            serializer.toByteArray(buffer, value, ts);
+            write(ts, buffer.getBuffer(), buffer.getReadOffset(), buffer.getAvailable());
+        }
+    }
+
+    private void write(long ts, byte[] data, int off, int len) throws IOException {
+        DataShard shard = getShard(ts, true);
+        try {
+            shard.write(ts, data, off, len);
+            checkOpenFiles(shard);
+        } finally {
+            shard.unlockWrite();
+        }
+    }
+
+    void insert(long shardId, List<Backdate> backdates) throws IOException {
+        DataShard shard = getShardById(shardId, true);
+        try {
+            shard.insertSamples(backdates);
+        } finally {
+            shard.unlockWrite();
+        }
+    }
+
+    void query(long fromTs, long toTs, int limit, boolean reverse, RawQueryCallback cb) throws IOException {
+        // Determine the shard range to query
+        long fromShard = Utils.getShardId(fromTs);
+        long toShard = Utils.getShardId(toTs);
+        synchronized (shardLookup) {
+            if (fromShard < minShard)
+                fromShard = minShard;
+            if (toShard > maxShard)
+                toShard = maxShard;
+        }
+
+        // Iterate through the shards.
+        for (long sid = fromShard; sid <= toShard; sid++) {
+            long shardId = sid;
+            if (reverse)
+                shardId = toShard - sid + fromShard;
+
+            // Get a handle on the current shard.
+            DataShard shard = getShardById(shardId, false);
+            try {
+                long fromOffset = Utils.getOffsetInShard(shardId, fromTs);
+                long toOffset = Utils.getOffsetInShard(shardId, toTs);
+
+                int count;
+                if (reverse)
+                    count = shard.queryReverse(fromOffset, toOffset, limit, cb);
+                else
+                    count = shard.query(fromOffset, toOffset, limit, cb);
+
+                if (limit != Integer.MAX_VALUE) {
+                    limit -= count;
+                    if (limit <= 0)
+                        // We found all the rows we need. Break from the shard loop.
+                        break;
+                }
+            } finally {
+                shard.unlockRead();
+            }
+        }
+    }
+
+    TimeRange getTimeRange() throws IOException {
+        long minShard, maxShard;
+
+        synchronized (shardLookup) {
+            minShard = this.minShard;
+            maxShard = this.maxShard;
+        }
+
+        if (maxShard == 0)
+            return null;
+
+        TimeRange range = new TimeRange();
+
+        DataShard min = getShardById(minShard, false);
+        try {
+            range.setFrom(min.getMinTs());
+            if (minShard == maxShard)
+                range.setTo(min.getMaxTs());
+            else {
+                DataShard max = getShardById(maxShard, false);
+                try {
+                    range.setTo(max.getMaxTs());
+                } finally {
+                    max.unlockRead();
+                }
+            }
+        } finally {
+            min.unlockRead();
+        }
+
+        return range;
+    }
+
+    long delete(long fromTs, long toTs) throws IOException {
+        long fromShard = Utils.getShardId(fromTs);
+        long toShard = Utils.getShardId(toTs);
+        long deleteCount = 0;
+
+        synchronized (shardLookup) {
+            if (fromShard < minShard)
+                fromShard = minShard;
+            if (toShard > maxShard)
+                toShard = maxShard;
+
+            for (long shardId = fromShard; shardId <= toShard; ++shardId) {
+                DataShard shard = getShardById(shardId, true);
+                try {
+                    long fromOffset = Utils.getOffsetInShard(shardId, fromTs);
+                    long toOffset = Utils.getOffsetInShard(shardId, toTs);
+                    deleteCount += shard.deleteSamples(fromOffset, toOffset);
+                } finally {
+                    shard.unlockWrite();
+                }
+            }
+        }
+        return deleteCount;
+    }
+
+    void purge(long toTs) {
+        long toShard = Utils.getShardId(toTs);
+
+        if (toShard <= minShard)
+            return;
+        if (toShard > maxShard)
+            toShard = maxShard + 1;
+
+        synchronized (shardLookup) {
+            for (long shardId = minShard; shardId < toShard; shardId++) {
+                DataShard shard = shardLookup.get(shardId);
+                if (shard != null) {
+                    try {
+                        shard.lockWrite();
+                        shard.close();
+                        shardLookup.remove(shardId);
+                        db.openShards.decrementAndGet();
+
+                        try {
+                            Utils.deleteWithRetry(new File(seriesDir, shardId + ".meta"));
+                        } catch (IOException e) {
+                            warn("Error while deleting shard meta " + shardId + " in series " + id, e);
+                        }
+
+                        try {
+                            Utils.deleteWithRetry(new File(seriesDir, shardId + ".data"));
+                        } catch (IOException e) {
+                            warn("Error while deleting shard data " + shardId + " in series " + id, e);
+                        }
+                    } finally {
+                        shard.unlockWrite();
+                    }
+                }
+            }
+
+            if (toShard > maxShard) {
+                minShard = Long.MAX_VALUE;
+                maxShard = 0;
+            } else
+                minShard = toShard;
+        }
+    }
+
+    int flush(long runtime, boolean force) throws IOException {
+        int closures = 0;
+
+        for (DataShard shard : getShards()) {
+            try {
+                shard.lockWrite();
+                shard.flush(runtime, force);
+                checkOpenFiles(shard);
+                closures = shard.resetMetaClosures();
+                if (shard.isClosed()) {
+                    synchronized (shardLookup) {
+                        shardLookup.remove(shard.getShardId());
+                        db.openShards.decrementAndGet();
+                    }
+                }
+            } finally {
+                shard.unlockWrite();
+            }
+        }
+
+        synchronized (buffer) {
+            synchronized (shardLookup) {
+                if (shardLookup.isEmpty()) {
+                    buffer.resetCapacity();
+                }
+            }
+        }
+
+        return closures;
+    }
+
+    private void checkOpenFiles(DataShard shard) {
+        if (db.tooManyFiles()) {
+            shard.closeFiles();
+            db.forcedClose.incrementAndGet();
+        }
+    }
+
+    void close() {
+        for (DataShard shard : getShards()) {
+            try {
+                shard.lockWrite();
+                shard.close();
+                synchronized (shardLookup) {
+                    shardLookup.remove(shard.getShardId());
+                    db.openShards.decrementAndGet();
+                }
+            } finally {
+                shard.unlockWrite();
+            }
+        }
+    }
+
+    private List<DataShard> getShards() {
+        List<DataShard> shards;
+        synchronized (shardLookup) {
+            shards = new ArrayList<>(shardLookup.values());
+        }
+        return shards;
+    }
+
+    //
+    //
+    // Private
+    //
+
+    private DataShard getShard(long ts, boolean writeLock) throws IOException {
+        return getShardById(Utils.getShardId(ts), writeLock);
+    }
+
+    private DataShard getShardById(long shardId, boolean writeLock) throws IOException {
+        // Enter the retry loop.
+        int attempts = 10;
+        while (attempts > 0) {
+            // Get the shard.
+            DataShard shard = _getShardById(shardId);
+
+            // Lock it appropriately
+            if (writeLock)
+                shard.lockWrite();
+            else
+                shard.lockRead();
+
+            // Check if it is already closed.
+            if (!shard.isClosed())
+                // If not, we're good, so just return it.
+                return shard;
+
+            // Unlock the shard.
+            if (writeLock)
+                shard.unlockWrite();
+            else
+                shard.unlockRead();
+
+            // Try again to get a shard that is not already closed.
+            attempts--;
+        }
+
+        // Too many attempts. Just give up.
+        throw new IOException("Failed to get unclosed shard in series " + id + ", shard " + shardId);
+    }
+
+    private DataShard _getShardById(long shardId) throws IOException {
+        DataShard shard = shardLookup.get(shardId);
+        if (shard == null) {
+            synchronized (shardLookup) {
+                shard = shardLookup.get(shardId);
+                if (shard == null) {
+                    shard = new DataShard(db, seriesDir, id, shardId);
+                    shardLookup.put(shardId, shard);
+                    db.openShards.incrementAndGet();
+                    updateMinMax(shardId);
+                }
+            }
+        }
+        return shard;
+    }
+
+    private void updateMinMax(long shardId) {
+        if (minShard > shardId)
+            minShard = shardId;
+        if (maxShard < shardId)
+            maxShard = shardId;
+    }
+}

--- a/src/main/java/org/etsdb/impl/Utils.java
+++ b/src/main/java/org/etsdb/impl/Utils.java
@@ -1,0 +1,293 @@
+package org.etsdb.impl;
+
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.iot.dsa.logging.DSLogger;
+
+public class Utils {
+    // This value must have at least one byte.
+    static final byte[] SAMPLE_HEADER = {(byte) 0xfe, (byte) 0xed};
+
+    public static final int MAX_DATA_LENGTH = 8192; // 8K
+    private static final DSLogger logger = new DSLogger() {
+        @Override
+        protected String getLogName() {
+            return Utils.class.getName();
+        }
+    };
+    private static int SHARD_BITS = 30;
+    // File IO retries
+    private static final int FILE_IO_RETRIES = 30;
+    private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
+    private static final Date date = new Date(0);
+
+    public static void setShardBits(int bits) {
+        SHARD_BITS = bits;
+    }
+
+    public static File getSeriesDir(File baseDir, String seriesId) {
+        return new File(baseDir, getShardDirectory(seriesId) + File.separator + seriesId);
+    }
+
+    /**
+     * The top level has maximum 100 directories.
+     *
+     * @param seriesId ID
+     * @return the top level directory in which the series data is stored.
+     */
+    public static long getShardDirectory(String seriesId) {
+        int i = seriesId.hashCode();
+        if (i < 0)
+            i = -i;
+        return i % 100;
+    }
+
+    /**
+     * Determines the name of the shard file for the given time stamp.
+     *
+     * @param ts the time stamp of the sample
+     * @return the name of the shard file.
+     */
+    public static long getShardId(long ts) {
+        return ts >> SHARD_BITS;
+    }
+
+    public static long getShardId(String filename) {
+        return getShardId(filename, 5);
+    }
+
+    public static long getShardId(String filename, int suffixLength) {
+        return Long.parseLong(filename.substring(0, filename.length() - suffixLength));
+    }
+
+    /**
+     * Returns the offset of the given ts within the given shard.
+     *
+     * @param shardId ID of the shard
+     * @param ts Timestamp
+     * @return offset
+     */
+    public static long getOffsetInShard(long shardId, long ts) {
+        long tsShardId = getShardId(ts);
+        if (tsShardId < shardId)
+            return 0;
+        if (tsShardId == shardId)
+            return getSampleOffset(ts);
+        return 0x40000000;
+    }
+
+    /**
+     * Determines the offset of the sample within the shard file.
+     *
+     * @param ts the time stamp of the sample
+     * @return the offset of the sample within the shard file.
+     */
+    public static long getSampleOffset(long ts) {
+        return ts & 0x3fffffff;
+    }
+
+    public static long getTimestamp(long shardFile, long offset) {
+        return (shardFile << SHARD_BITS) | offset;
+    }
+
+    public static void closeQuietly(Closeable c) {
+        try {
+            if (c != null)
+                c.close();
+        } catch (IOException e) {
+            logger.warn("Exception during close", e);
+        }
+    }
+
+    public static String prettyTimestamp(long ts) {
+        synchronized (sdf) {
+            date.setTime(ts);
+            return sdf.format(date);
+        }
+    }
+
+    public static void writeCompactInt(OutputStream out, int i) throws IOException {
+        // Convert to unsigned.
+        putCompactLong(out, i & 0xffffffffL);
+    }
+
+    public static void putCompactLong(OutputStream out, long l) throws IOException {
+        if (l < 0)
+            throw new IllegalArgumentException("Cannot store negative numbers");
+        while (true) {
+            if (l < 128) {
+                out.write((byte) l);
+                break;
+            }
+            out.write(((byte) l) | 0x80);
+            l = l >> 7;
+        }
+    }
+
+    public static int readCompactInt(Input in) throws IOException {
+        return (int) readCompactLong(in);
+    }
+
+    public static long readCompactLong(Input in) throws IOException {
+        long result = 0;
+        int count = 0;
+        while (true) {
+            long l = in.read();
+            if (l == -1)
+                throw new IOException("EOF");
+            result |= (l & 0x7f) << (count++ * 7);
+            if (l < 128)
+                break;
+        }
+        return result;
+    }
+
+    public static boolean skip(InputStream in, long n) throws IOException {
+        while (n > 0) {
+            long skipped = in.skip(n);
+            if (skipped == 0) {
+                // Check if we've reached the EOF
+                in.mark(1);
+                int i = in.read();
+                in.reset();
+                if (i == -1)
+                    return true;
+            }
+            n -= skipped;
+        }
+
+        return false;
+    }
+
+    public static void deleteWithRetry(File file) throws IOException {
+        if (!file.exists())
+            return;
+
+        int retries = FILE_IO_RETRIES;
+        while (true) {
+            if (file.delete())
+                break;
+
+            if (retries == 0)
+                throw new IOException("Failed to delete " + file);
+
+            retries--;
+            logger.trace("Failed to delete " + file + ", " + retries + " retries left");
+            sleep(FILE_IO_RETRIES - retries);
+        }
+    }
+
+    public static void renameWithRetry(File from, File to) throws IOException {
+        int retries = FILE_IO_RETRIES;
+        while (true) {
+            if (from.renameTo(to))
+                break;
+            if (retries == 0)
+                throw new IOException("Failed to rename " + from + " to " + to);
+
+            retries--;
+            logger.trace("Failed to rename " + from + " to " + to + ", " + retries + " retries left");
+            sleep(FILE_IO_RETRIES - retries);
+        }
+    }
+
+    public static void delete(File file) throws IOException {
+        if (!file.exists())
+            return;
+
+        String message = null;
+        while (true) {
+            try {
+                _delete(file);
+                break;
+            } catch (IOException e) {
+                if (e.getMessage() != null) {
+                    if (message == null)
+                        message = e.getMessage();
+                    else {
+                        if (e.getMessage().equals(message))
+                            throw e;
+                    }
+                } else
+                    throw e;
+            }
+        }
+    }
+
+    private static void _delete(File file) throws IOException {
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File file1 : files) {
+                    delete(file1);
+                }
+            }
+        }
+
+        if (!file.delete())
+            throw new IOException("Failed to delete " + file);
+    }
+
+    public static void deleteEmptyDirs(File file) {
+        if (file.isDirectory()) {
+            // Recurse to leaves.
+            File[] files = file.listFiles();
+            if (files != null && files.length > 0) {
+                boolean hasFiles = false;
+                for (File subFile : files) {
+                    if (!subFile.isDirectory())
+                        hasFiles = true;
+                    deleteEmptyDirs(subFile);
+                }
+                if (!hasFiles)
+                    files = file.listFiles();
+            }
+
+            if (files == null || files.length == 0) {
+                if (!file.delete()) {
+                    logger.error("Failed to delete empty dir: " + file.getPath());
+                }
+            }
+        }
+    }
+
+    public static void write4ByteUnsigned(OutputStream out, long l) throws IOException {
+        out.write((byte) (l >> 24));
+        out.write((byte) (l >> 16));
+        out.write((byte) (l >> 8));
+        out.write((byte) l);
+    }
+
+    public static long read4ByteUnsigned(Input in) throws IOException {
+        long l = 0;
+        l |= (in.read() & 0xff) << 24;
+        l |= (in.read() & 0xff) << 16;
+        l |= (in.read() & 0xff) << 8;
+        l |= in.read() & 0xff;
+        return l;
+    }
+
+    public static void sleep(int time) {
+        try {
+            if (time > 0)
+                Thread.sleep(time);
+        } catch (InterruptedException e) {
+            // Ignore
+        }
+    }
+
+    public static int compareLong(long l1, long l2) {
+        if (l1 < l2)
+            return -1;
+        if (l1 == l2)
+            return 0;
+        return 1;
+    }
+
+    public static byte[] copy(byte[] data, int off, int len) {
+        byte[] b = new byte[len];
+        System.arraycopy(data, off, b, 0, len);
+        return b;
+    }
+}

--- a/src/main/java/org/etsdb/impl/WriteQueueInfo.java
+++ b/src/main/java/org/etsdb/impl/WriteQueueInfo.java
@@ -1,0 +1,41 @@
+package org.etsdb.impl;
+
+import org.etsdb.util.atomic.NotifyAtomicInteger;
+import org.etsdb.DbConfig;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class WriteQueueInfo {
+    final int discardQueueSize;
+    final int expireMinimum;
+    final int expireMaximum;
+    final int shardQueueSizeMinimum;
+    final int shardQueueSizeMaximum;
+    final int maxQueueSize;
+
+    final NotifyAtomicInteger queueSize = new NotifyAtomicInteger();
+    final AtomicInteger recentDiscards = new AtomicInteger();
+    final Random random = new Random();
+
+    public WriteQueueInfo(DbConfig config) {
+        expireMinimum = config.getQueueExpireMinimum();
+        expireMaximum = config.getQueueExpireMaximum();
+        shardQueueSizeMinimum = config.getQueueShardQueueSizeMinimum();
+        shardQueueSizeMaximum = config.getQueueShardQueueSizeMaximum();
+        maxQueueSize = config.getQueueMaxQueueSize();
+        discardQueueSize = config.getQueueDiscardQueueSize();
+    }
+
+    public long getExpiryTime() {
+        if (expireMinimum == expireMaximum)
+            return System.currentTimeMillis() + expireMinimum;
+        return System.currentTimeMillis() + expireMinimum + random.nextInt(expireMaximum - expireMinimum);
+    }
+
+    public int getShardQueueSize() {
+        if (shardQueueSizeMinimum == shardQueueSizeMaximum)
+            return shardQueueSizeMinimum;
+        return shardQueueSizeMinimum + random.nextInt(shardQueueSizeMaximum - shardQueueSizeMinimum);
+    }
+}

--- a/src/main/java/org/etsdb/util/AbstractProperties.java
+++ b/src/main/java/org/etsdb/util/AbstractProperties.java
@@ -1,0 +1,85 @@
+package org.etsdb.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.iot.dsa.logging.DSLogger;
+
+public abstract class AbstractProperties extends DSLogger {
+    private static final Pattern PATTERN_ENV = Pattern.compile("(\\$\\{env:(.+?)\\})");
+    private static final Pattern PATTERN_PROP = Pattern.compile("(\\$\\{prop:(.+?)\\})");
+    private static final Pattern PATTERN_BS = Pattern.compile("\\\\");
+    private static final Pattern PATTERN_DOL = Pattern.compile("\\$");
+    private final String description;
+
+    public AbstractProperties() {
+        this("unnamed");
+    }
+
+    public AbstractProperties(String description) {
+        this.description = description;
+    }
+
+    public String getString(String key) {
+        String s = getStringImpl(key);
+        if (s == null) {
+            return null;
+        }
+        Matcher matcher = PATTERN_ENV.matcher(s);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String pkey = matcher.group(2);
+            matcher.appendReplacement(sb, escape(System.getenv(pkey)));
+        }
+        matcher.appendTail(sb);
+
+        matcher = PATTERN_PROP.matcher(sb.toString());
+        sb = new StringBuffer();
+        while (matcher.find()) {
+            String pkey = matcher.group(2);
+            matcher.appendReplacement(sb, escape(System.getProperty(pkey)));
+        }
+        matcher.appendTail(sb);
+
+        return sb.toString();
+    }
+
+    private String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        s = PATTERN_BS.matcher(s).replaceAll("\\\\\\\\");
+        s = PATTERN_DOL.matcher(s).replaceAll("\\\\\\$");
+
+        return s;
+    }
+
+    protected abstract String getStringImpl(String paramString);
+
+    public int getInt(String key, int defaultValue) {
+        String value = getString(key);
+        if ("".equals(value)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            warn("(" + this.description + ") Can't parse int from properties key: " + key + ", value=" + value);
+        }
+        return defaultValue;
+    }
+
+    public boolean getBoolean(String key, boolean defaultValue) {
+        String value = getString(key);
+        if ("".equals(value)) {
+            return defaultValue;
+        }
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        warn("(" + this.description + ") Can't parse boolean from properties key: " + key + ", value=" + value);
+        return defaultValue;
+    }
+}

--- a/src/main/java/org/etsdb/util/DbPurger.java
+++ b/src/main/java/org/etsdb/util/DbPurger.java
@@ -1,0 +1,114 @@
+package org.etsdb.util;
+
+import org.apache.commons.io.FileUtils;
+import org.etsdb.Database;
+import org.etsdb.TimeRange;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ScheduledFuture;
+
+
+public class DbPurger {
+    private static DbPurger singleton = null;
+    
+    private Map<Database<?>, PurgeSettings> databases = new HashMap<Database<?>, PurgeSettings>();
+    private ScheduledFuture<?> fut;
+    private boolean running;
+    
+    private DbPurger() {
+    }
+    
+    public static DbPurger getInstance() {
+        if (singleton == null) {
+            singleton = new DbPurger();
+        }
+        return singleton;
+    }
+
+    public synchronized void addDb(Database<?> db, PurgeSettings purgeSettings) {
+        if (!databases.containsKey(db)) {
+            databases.put(db, purgeSettings);
+        }
+    }
+
+    public synchronized void removeDb(Database<?> db) {
+        databases.remove(db);
+    }
+
+    public void stop() {
+        running = false;
+        synchronized (this) {
+            if (fut != null) {
+                fut.cancel(true);
+            }
+        }
+    }
+
+    public Runnable setupPurger() {
+        running = true;
+        Runnable runner = new Runnable() {
+            @Override
+            public void run() {
+                for (Entry<Database<?>, PurgeSettings> entry : databases.entrySet()) {
+                    Database<?> db = entry.getKey();
+                    PurgeSettings settings = entry.getValue();
+                    if (!(settings.isPurgeEnabled() && running)) {
+                        continue;
+                    }
+
+                    File path = db.getBaseDir();
+                    long currSize = FileUtils.sizeOf(path);
+                    long maxSize = settings.getMaxSizeInBytes();
+                    long delCount = 0;
+//                    LOGGER.info("Deciding whether to purge");
+//                    LOGGER.info("curr = " + curr + " , request = " + request);
+                    if (maxSize - currSize <= 0) {
+                        if (!running) {
+                            break;
+                        }
+//                        LOGGER.info("Going to purge");
+
+                        List<String> series = db.getSeriesIds();
+                        if (File.separatorChar != '/') {
+                        	List<String> corrected = new ArrayList<String>();
+	                        for (String s: series) {
+	                        	corrected.add(s.replace(File.separatorChar, '/'));
+	                        }
+	                        series = corrected;
+                        }
+//                        LOGGER.info("Purge Step 1");
+                        while (maxSize - currSize <= 0) {
+//                        	LOGGER.info("Purge Step 2");
+	                        TimeRange range = db.getTimeRange(series);
+	                        if (range == null || range.isUndefined()) {
+	                            break;
+	                        }
+//	                        LOGGER.info("Purge Step 3");
+	                        long from = range.getFrom();
+	                        for (String s : series) {
+//	                        	LOGGER.info("Purge Step 4");
+	                            delCount += db.delete(s, from, from + 3600000);
+	                        }
+//	                        LOGGER.info("Purge Step 5");
+	                        if (delCount <= 0) {
+	                            break;
+	                        }
+//	                        LOGGER.info("Purge Step 6");
+	                        currSize = FileUtils.sizeOf(path);
+//	                        LOGGER.info("Purge Step 7: curr = " + curr + " , request = " + request);
+                        }
+                    }
+                    if (delCount > 0) {
+//                        String p = path.getPath();
+//                        LOGGER.info("Deleted {} records from {}", delCount, p);
+                    }
+                }
+            }
+        };
+        return runner;
+    }
+}

--- a/src/main/java/org/etsdb/util/DirectoryInfo.java
+++ b/src/main/java/org/etsdb/util/DirectoryInfo.java
@@ -1,0 +1,14 @@
+package org.etsdb.util;
+
+public class DirectoryInfo {
+    int count;
+    long size;
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public long getSize() {
+        return this.size;
+    }
+}

--- a/src/main/java/org/etsdb/util/DirectoryUtils.java
+++ b/src/main/java/org/etsdb/util/DirectoryUtils.java
@@ -1,0 +1,26 @@
+package org.etsdb.util;
+
+import java.io.File;
+
+public class DirectoryUtils {
+
+    public static DirectoryInfo getSize(File file) {
+        DirectoryInfo info = new DirectoryInfo();
+        getSizeImpl(info, file);
+        return info;
+    }
+
+    private static void getSizeImpl(DirectoryInfo info, File file) {
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File subFile : files) {
+                    getSizeImpl(info, subFile);
+                }
+            }
+        } else {
+            info.count += 1;
+            info.size += file.length();
+        }
+    }
+}

--- a/src/main/java/org/etsdb/util/EventHistogram.java
+++ b/src/main/java/org/etsdb/util/EventHistogram.java
@@ -1,0 +1,65 @@
+package org.etsdb.util;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class EventHistogram {
+
+    private final int bucketSize;
+    private final int[] buckets;
+    private final AtomicLong lastTime = new AtomicLong();
+
+    private int position;
+
+    public EventHistogram(int bucketSize, int buckets) {
+        this.bucketSize = bucketSize;
+        this.buckets = new int[buckets];
+        this.position = 0;
+        this.lastTime.set(System.currentTimeMillis() / bucketSize);
+    }
+
+    public static void main(String[] args)
+            throws Exception {
+        Random random = new Random();
+        EventHistogram ec = new EventHistogram(1000, 60);
+        for (int i = 0; i < 1000; i++) {
+            ec.hit();
+            Thread.sleep(random.nextInt(100));
+        }
+        System.out.println(Arrays.toString(ec.getEventCounts()));
+    }
+
+    public void hit() {
+        update();
+        this.buckets[this.position] += 1;
+    }
+
+    public int[] getEventCounts() {
+        return getEventCounts(true);
+    }
+
+    private int[] getEventCounts(boolean update) {
+        if (update) {
+            update();
+        }
+
+        int[] result = new int[this.buckets.length];
+        int pos = this.position % this.buckets.length + 1;
+
+        System.arraycopy(this.buckets, pos, result, 0, this.buckets.length - pos);
+        System.arraycopy(this.buckets, 0, result, this.buckets.length - pos, pos);
+
+        return result;
+    }
+
+    private void update() {
+        long thisTime = System.currentTimeMillis() / this.bucketSize;
+        int diff = (int) (thisTime - this.lastTime.getAndSet(thisTime));
+        while (diff > 0) {
+            this.position = ((this.position + 1) % this.buckets.length);
+            this.buckets[this.position] = 0;
+            diff--;
+        }
+    }
+}

--- a/src/main/java/org/etsdb/util/Handler.java
+++ b/src/main/java/org/etsdb/util/Handler.java
@@ -1,0 +1,7 @@
+package org.etsdb.util;
+
+public interface Handler<T> {
+
+    void handle(T event);
+
+}

--- a/src/main/java/org/etsdb/util/PurgeSettings.java
+++ b/src/main/java/org/etsdb/util/PurgeSettings.java
@@ -1,0 +1,9 @@
+package org.etsdb.util;
+
+public interface PurgeSettings {
+    
+    public boolean isPurgeEnabled();
+    
+    public long getMaxSizeInBytes();
+
+}

--- a/src/main/java/org/etsdb/util/atomic/NotifyAtomicInteger.java
+++ b/src/main/java/org/etsdb/util/atomic/NotifyAtomicInteger.java
@@ -1,0 +1,40 @@
+package org.etsdb.util.atomic;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.etsdb.util.Handler;
+
+/**
+ * @author Samuel Grenier
+ */
+public class NotifyAtomicInteger {
+
+    private final AtomicInteger aInt = new AtomicInteger();
+    private Handler<Integer> handler;
+
+    public void setHandler(Handler<Integer> handler) {
+        this.handler = handler;
+    }
+
+    public int get() {
+        return aInt.get();
+    }
+
+    public int addAndGet(int i) {
+        return notifyHandler(aInt.addAndGet(i));
+    }
+
+    public int incrementAndGet() {
+        return notifyHandler(aInt.incrementAndGet());
+    }
+
+    public int decrementAndGet() {
+        return notifyHandler(aInt.decrementAndGet());
+    }
+
+    private int notifyHandler(int i) {
+        if (handler != null) {
+            handler.handle(i);
+        }
+        return i;
+    }
+}

--- a/src/main/java/org/etsdb/util/atomic/NotifyAtomicLong.java
+++ b/src/main/java/org/etsdb/util/atomic/NotifyAtomicLong.java
@@ -1,0 +1,41 @@
+package org.etsdb.util.atomic;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.etsdb.util.Handler;
+
+/**
+ * @author Samuel Grenier
+ */
+public class NotifyAtomicLong {
+
+    private final AtomicLong aLong = new AtomicLong();
+    private Handler<Long> handler;
+
+    public void setHandler(Handler<Long> handler) {
+        this.handler = handler;
+    }
+
+    public long get() {
+        return aLong.get();
+    }
+
+    public void set(long val) {
+        aLong.set(val);
+        notifyHandler(val);
+    }
+
+    public long addAndGet(long l) {
+        return notifyHandler(aLong.addAndGet(l));
+    }
+
+    public long incrementAndGet() {
+        return notifyHandler(aLong.incrementAndGet());
+    }
+
+    private long notifyHandler(long l) {
+        if (handler != null) {
+            handler.handle(l);
+        }
+        return l;
+    }
+}

--- a/src/main/java/org/etsdb/util/queue/LongLimitQueue.java
+++ b/src/main/java/org/etsdb/util/queue/LongLimitQueue.java
@@ -1,0 +1,74 @@
+package org.etsdb.util.queue;
+
+public class LongLimitQueue {
+    private final long[] queue;
+    private int head = -1;
+    private int tail = 0;
+    private int size = 0;
+
+    public LongLimitQueue(int limit) {
+        this.queue = new long[limit];
+    }
+
+    public void push(long l) {
+        this.queue[this.tail] = l;
+
+        this.tail = ((this.tail + 1) % this.queue.length);
+        if (this.head == -1) {
+            this.head = 0;
+            this.size = 1;
+        } else if (this.size == this.queue.length) {
+            this.head = this.tail;
+        } else {
+            this.size += 1;
+        }
+    }
+
+    public long pop() {
+        long retval = this.queue[this.head];
+        if (this.size == 1) {
+            this.head = -1;
+            this.tail = 0;
+        } else {
+            this.head = ((this.head + 1) % this.queue.length);
+        }
+        this.size -= 1;
+
+        return retval;
+    }
+
+    public long peek(int index) {
+        if (index >= this.size) {
+            throw new IllegalArgumentException("index " + index + " is >= queue size " + this.size);
+        }
+        index = (index + this.head) % this.queue.length;
+        return this.queue[index];
+    }
+
+    public int size() {
+        return this.size;
+    }
+
+    public void clear() {
+        this.head = -1;
+        this.tail = 0;
+        this.size = 0;
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        if (this.queue.length == 0) {
+            sb.append("[]");
+        } else {
+            sb.append('[');
+            sb.append(this.queue[0]);
+            for (int i = 1; i < this.queue.length; i++) {
+                sb.append(", ");
+                sb.append(this.queue[i]);
+            }
+            sb.append("]");
+        }
+        sb.append(", h=").append(this.head).append(", t=").append(this.tail).append(", s=").append(this.size);
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/etsdb/util/queue/LongQueue.java
+++ b/src/main/java/org/etsdb/util/queue/LongQueue.java
@@ -1,0 +1,295 @@
+package org.etsdb.util.queue;
+
+public class LongQueue implements Cloneable {
+    private long[] queue;
+    private int head = -1;
+    private int tail = 0;
+    private int size = 0;
+
+    public LongQueue() {
+        this(128);
+    }
+
+    public LongQueue(int initialLength) {
+        this.queue = new long[initialLength];
+    }
+
+    public LongQueue(long[] i) {
+        this(i.length);
+        push(i, 0, i.length);
+    }
+
+    public LongQueue(long[] i, int pos, int length) {
+        this(length);
+        push(i, pos, length);
+    }
+
+    public void push(long i) {
+        if (room() == 0) {
+            expand();
+        }
+        this.queue[this.tail] = i;
+        if (this.head == -1) {
+            this.head = 0;
+        }
+        this.tail = ((this.tail + 1) % this.queue.length);
+        this.size += 1;
+    }
+
+    public void push(long[] i) {
+        push(i, 0, i.length);
+    }
+
+    public void push(long[] i, int pos, int length) {
+        if (length == 0) {
+            return;
+        }
+        while (room() < length) {
+            expand();
+        }
+        int tailLength = this.queue.length - this.tail;
+        if (tailLength > length) {
+            System.arraycopy(i, pos, this.queue, this.tail, length);
+        } else {
+            System.arraycopy(i, pos, this.queue, this.tail, tailLength);
+        }
+        if (length > tailLength) {
+            System.arraycopy(i, tailLength + pos, this.queue, 0, length - tailLength);
+        }
+        if (this.head == -1) {
+            this.head = 0;
+        }
+        this.tail = ((this.tail + length) % this.queue.length);
+        this.size += length;
+    }
+
+    public void push(LongQueue source) {
+        if (source.size == 0) {
+            return;
+        }
+        if (source == this) {
+            source = (LongQueue) clone();
+        }
+        int firstCopyLen = source.queue.length - source.head;
+        if (source.size < firstCopyLen) {
+            firstCopyLen = source.size;
+        }
+        push(source.queue, source.head, firstCopyLen);
+        if (firstCopyLen < source.size) {
+            push(source.queue, 0, source.tail);
+        }
+    }
+
+    public long pop() {
+        long retval = this.queue[this.head];
+        if (this.size == 1) {
+            this.head = -1;
+            this.tail = 0;
+        } else {
+            this.head = ((this.head + 1) % this.queue.length);
+        }
+        this.size -= 1;
+
+        return retval;
+    }
+
+    public int pop(long[] buf) {
+        return pop(buf, 0, buf.length);
+    }
+
+    public int pop(long[] buf, int pos, int length) {
+        length = peek(buf, pos, length);
+
+        this.size -= length;
+        if (this.size == 0) {
+            this.head = -1;
+            this.tail = 0;
+        } else {
+            this.head = ((this.head + length) % this.queue.length);
+        }
+        return length;
+    }
+
+    public int pop(int length) {
+        if (length == 0) {
+            return 0;
+        }
+        if (this.size == 0) {
+            throw new ArrayIndexOutOfBoundsException(-1);
+        }
+        if (length > this.size) {
+            length = this.size;
+        }
+        this.size -= length;
+        if (this.size == 0) {
+            this.head = -1;
+            this.tail = 0;
+        } else {
+            this.head = ((this.head + length) % this.queue.length);
+        }
+        return length;
+    }
+
+    public long[] popAll() {
+        long[] data = new long[this.size];
+        pop(data);
+        return data;
+    }
+
+    public long tailPop() {
+        if (this.size == 0) {
+            throw new ArrayIndexOutOfBoundsException(-1);
+        }
+        this.tail = ((this.tail + this.queue.length - 1) % this.queue.length);
+        long retval = this.queue[this.tail];
+        if (this.size == 1) {
+            this.head = -1;
+            this.tail = 0;
+        }
+        this.size -= 1;
+
+        return retval;
+    }
+
+    public long peek(int index) {
+        if (index >= this.size) {
+            throw new IllegalArgumentException("index " + index + " is >= queue size " + this.size);
+        }
+        index = (index + this.head) % this.queue.length;
+        return this.queue[index];
+    }
+
+    public long[] peek(int index, int length) {
+        long[] result = new long[length];
+        for (int i = 0; i < length; i++) {
+            result[i] = peek(index + i);
+        }
+        return result;
+    }
+
+    public int peek(long[] buf) {
+        return peek(buf, 0, buf.length);
+    }
+
+    public int peek(long[] buf, int pos, int length) {
+        if (length == 0) {
+            return 0;
+        }
+        if (this.size == 0) {
+            throw new ArrayIndexOutOfBoundsException(-1);
+        }
+        if (length > this.size) {
+            length = this.size;
+        }
+        int firstCopyLen = this.queue.length - this.head;
+        if (length < firstCopyLen) {
+            firstCopyLen = length;
+        }
+        System.arraycopy(this.queue, this.head, buf, pos, firstCopyLen);
+        if (firstCopyLen < length) {
+            System.arraycopy(this.queue, 0, buf, pos + firstCopyLen, length - firstCopyLen);
+        }
+        return length;
+    }
+
+    public int indexOf(long i) {
+        return indexOf(i, 0);
+    }
+
+    public int indexOf(long value, int start) {
+        if (start >= this.size) {
+            return -1;
+        }
+        int index = (this.head + start) % this.queue.length;
+        for (int i = start; i < this.size; i++) {
+            if (this.queue[index] == value) {
+                return i;
+            }
+            index = (index + 1) % this.queue.length;
+        }
+        return -1;
+    }
+
+    public int indexOf(long[] values) {
+        return indexOf(values, 0);
+    }
+
+    public int indexOf(long[] values, int start) {
+        if ((values == null) || (values.length == 0)) {
+            throw new IllegalArgumentException("cannot search for empty values");
+        }
+        while (((start = indexOf(values[0], start)) != -1) && (start < this.size - values.length + 1)) {
+            boolean found = true;
+            for (int i = 1; i < values.length; i++) {
+                if (peek(start + i) != values[i]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                return start;
+            }
+            start++;
+        }
+        return -1;
+    }
+
+    public int size() {
+        return this.size;
+    }
+
+    public void clear() {
+        this.size = 0;
+        this.head = -1;
+        this.tail = 0;
+    }
+
+    private int room() {
+        return this.queue.length - this.size;
+    }
+
+    private void expand() {
+        long[] newq = new long[this.queue.length * 2];
+        if (this.head == -1) {
+            this.queue = newq;
+            return;
+        }
+        if (this.tail > this.head) {
+            System.arraycopy(this.queue, this.head, newq, this.head, this.tail - this.head);
+            this.queue = newq;
+            return;
+        }
+        System.arraycopy(this.queue, this.head, newq, this.head + this.queue.length, this.queue.length - this.head);
+        System.arraycopy(this.queue, 0, newq, 0, this.tail);
+        this.head += this.queue.length;
+        this.queue = newq;
+    }
+
+    public Object clone() {
+        try {
+            LongQueue clone = (LongQueue) super.clone();
+
+            clone.queue = this.queue.clone();
+            return clone;
+        } catch (CloneNotSupportedException e) {
+        }
+        return null;
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        if (this.queue.length == 0) {
+            sb.append("[]");
+        } else {
+            sb.append('[');
+            sb.append(this.queue[0]);
+            for (int i = 1; i < this.queue.length; i++) {
+                sb.append(", ");
+                sb.append(this.queue[i]);
+            }
+            sb.append("]");
+        }
+        sb.append(", h=").append(this.head).append(", t=").append(this.tail).append(", s=").append(this.size);
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/iot/dsa/dslink/restadapter/AbstractRuleNode.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/AbstractRuleNode.java
@@ -1,14 +1,54 @@
 package org.iot.dsa.dslink.restadapter;
 
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.iot.dsa.node.DSBool;
+import org.iot.dsa.node.DSIObject;
+import org.iot.dsa.node.DSIValue;
+import org.iot.dsa.node.DSInfo;
+import org.iot.dsa.node.DSLong;
 import org.iot.dsa.node.DSNode;
 
 public abstract class AbstractRuleNode extends DSNode {
+    private DSInfo bufferEnabled = getInfo(Constants.USE_BUFFER);
+    private DSInfo maxBatchSize = getInfo(Constants.MAX_BATCH_SIZE);
+    private String id;
 
     public WebClientProxy getWebClientProxy() {
         return ((ConnectionNode) getParent()).getWebClientProxy();
     }
 
     public abstract void responseRecieved(Response resp, int rowNum);
+    
+    @Override
+    protected void declareDefaults() {
+        super.declareDefaults();
+        declareDefault(Constants.USE_BUFFER, DSBool.FALSE, "Whether updates that failed to send should be stored and re-sent in the future");
+        declareDefault(Constants.MAX_BATCH_SIZE, DSLong.valueOf(50), "Maximum number of updates to put in a single REST request");
+    }
+    
+    public boolean isBufferEnabled() {
+        return bufferEnabled.getValue().toElement().toBoolean();
+    }
+    
+    public int getMaxBatchSize() {
+        return maxBatchSize.getValue().toElement().toInt();
+    }
+    
+    @Override
+    protected void onStarted() {
+        super.onStarted();
+        DSIObject idobj = get("id");
+        if (idobj instanceof DSIValue) {
+            id = ((DSIValue) idobj).toElement().toString();
+        } else {
+            id = RandomStringUtils.randomAlphanumeric(12);
+            put("id", id);
+        }
+    }
+    
+    public String getId() {
+        return id;
+    }
 
 }

--- a/src/main/java/org/iot/dsa/dslink/restadapter/Constants.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/Constants.java
@@ -20,6 +20,10 @@ public class Constants {
     public static final String RULE_TABLE = "Table";
     public static final String MIN_REFRESH_RATE = "Minimum Refresh Rate";
     public static final String MAX_REFRESH_RATE = "Maximum Refresh Rate";
+    public static final String USE_BUFFER = "Buffer Enabled";
+    public static final String MAX_BATCH_SIZE = "Maximum Batch Size";
+    public static final String BUFFER_PURGE_ENABLED = "Enable Buffer Auto-Purge";
+    public static final String BUFFER_MAX_SIZE = "Maximum Buffer Size";
     
     //Actions
     public static final String ACT_ADD_BASIC_CONN = "Basic Connection";
@@ -42,4 +46,9 @@ public class Constants {
     public static final String PLACEHOLDER_VALUE = "%VALUE%";
     public static final String PLACEHOLDER_TS = "%TIMESTAMP%";
     public static final String PLACEHOLDER_STATUS = "%STATUS%";
+    public static final String PLACEHOLDER_BLOCK_START = "%STARTBLOCK%";
+    public static final String PLACEHOLDER_BLOCK_END = "%ENDBLOCK%";
+    
+    //MISC
+    public static final String BUFFER_PATH = "buffer";
 }

--- a/src/main/java/org/iot/dsa/dslink/restadapter/RuleNode.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/RuleNode.java
@@ -41,6 +41,7 @@ public class RuleNode extends AbstractRuleNode {
     
     @Override
     protected void onStarted() {
+        super.onStarted();
         if (this.parameters == null) {
             DSIObject o = get(Constants.PARAMS);
             if (o instanceof DSMap) {
@@ -133,12 +134,18 @@ public class RuleNode extends AbstractRuleNode {
 
     @Override
     public void responseRecieved(Response resp, int rowNum) {
-        int status = resp.getStatus();
-        String data = resp.readEntity(String.class);
-        
-        put(lastRespCode, DSInt.valueOf(status));
-        put(lastRespData, DSString.valueOf(data));
-        put(lastRespTs, DSString.valueOf(resp.getDate() != null ? DSDateTime.valueOf(resp.getDate().getTime()) : DSDateTime.currentTime()));
+        if (resp == null) {
+            put(lastRespCode, DSInt.valueOf(-1));
+            put(lastRespData, DSString.valueOf("Failed to send update"));
+            put(lastRespTs, DSString.valueOf(DSDateTime.currentTime()));
+        } else {
+            int status = resp.getStatus();
+            String data = resp.readEntity(String.class);
+            
+            put(lastRespCode, DSInt.valueOf(status));
+            put(lastRespData, DSString.valueOf(data));
+            put(lastRespTs, DSString.valueOf(resp.getDate() != null ? DSDateTime.valueOf(resp.getDate().getTime()) : DSDateTime.currentTime()));
+        }
     }
 
 }

--- a/src/main/java/org/iot/dsa/dslink/restadapter/RuleTableNode.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/RuleTableNode.java
@@ -28,16 +28,23 @@ public class RuleTableNode extends AbstractRuleNode {
 
     @Override
     public void responseRecieved(Response resp, int rowNum) {
-        int status = resp.getStatus();
-        String data = resp.readEntity(String.class);
-
         DSList respTable = lastResponses.getElement().toList();
         DSMap respMap = respTable.getMap(rowNum);
-        respMap.put(Constants.LAST_RESPONSE_CODE, status);
-        respMap.put(Constants.LAST_RESPONSE_DATA, data);
-        respMap.put(Constants.LAST_RESPONSE_TS,
-                    (resp.getDate() != null ? DSDateTime.valueOf(resp.getDate().getTime())
-                            : DSDateTime.currentTime()).toString());
+        
+        if (resp == null) {
+            respMap.put(Constants.LAST_RESPONSE_CODE, -1);
+            respMap.put(Constants.LAST_RESPONSE_DATA, "Failed to send update");
+            respMap.put(Constants.LAST_RESPONSE_TS, DSDateTime.currentTime().toString());
+        } else {
+            int status = resp.getStatus();
+            String data = resp.readEntity(String.class);
+    
+            respMap.put(Constants.LAST_RESPONSE_CODE, status);
+            respMap.put(Constants.LAST_RESPONSE_DATA, data);
+            respMap.put(Constants.LAST_RESPONSE_TS,
+                        (resp.getDate() != null ? DSDateTime.valueOf(resp.getDate().getTime())
+                                : DSDateTime.currentTime()).toString());
+        }
         fire(VALUE_CHANGED, lastResponses);
     }
 
@@ -63,6 +70,7 @@ public class RuleTableNode extends AbstractRuleNode {
 
     @Override
     protected void onStarted() {
+        super.onStarted();
         if (this.table == null) {
             DSIObject o = get(Constants.RULE_TABLE);
             if (o instanceof DSList) {

--- a/src/main/java/org/iot/dsa/dslink/restadapter/SubUpdate.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/SubUpdate.java
@@ -1,0 +1,24 @@
+package org.iot.dsa.dslink.restadapter;
+
+import org.iot.dsa.node.DSElement;
+import org.iot.dsa.node.DSStatus;
+import org.iot.dsa.time.DSDateTime;
+
+public class SubUpdate {
+    
+    public final String dateTime;
+    public final String value;
+    public final String status;
+    public final long ts;
+    
+    public SubUpdate(String dateTime, String value, String status, long ts) {
+        this.dateTime = dateTime;
+        this.value = value;
+        this.status = status;
+        this.ts = ts;
+    }
+    
+    public SubUpdate(DSDateTime dateTime, DSElement value, DSStatus status) {
+        this(dateTime.toString(), value.toString(), status.toString(), dateTime.timeInMillis());
+    }
+}

--- a/src/main/java/org/iot/dsa/dslink/restadapter/SubUpdateSerializer.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/SubUpdateSerializer.java
@@ -1,0 +1,48 @@
+package org.iot.dsa.dslink.restadapter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.etsdb.ByteArrayBuilder;
+import org.etsdb.Serializer;
+import org.iot.dsa.io.json.JsonReader;
+import org.iot.dsa.io.json.JsonWriter;
+import org.iot.dsa.node.DSList;
+import org.iot.dsa.node.DSString;
+
+public class SubUpdateSerializer extends Serializer<SubUpdate> {
+
+    @Override
+    public void toByteArray(final ByteArrayBuilder builder, SubUpdate obj, long ts) {
+        JsonWriter jw = new JsonWriter(new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                builder.put((byte) b); 
+            }
+        });
+        jw.beginList();
+        jw.value(obj.dateTime);
+        jw.value(obj.value);
+        jw.value(obj.status);
+        jw.endList();
+        jw.close();
+    }
+
+    @Override
+    public SubUpdate fromByteArray(ByteArrayBuilder builder, long ts) {
+        JsonReader jr = new JsonReader(new InputStream() {
+            @Override
+            public int read() throws IOException {
+                return builder.getAvailable() > 0 ? builder.getByte() : -1;
+            }
+        }, DSString.UTF8.name());
+        jr.next();
+        DSList l = jr.getList();
+        jr.close();
+        if (l.size() < 3) {
+            throw new RuntimeException("Failed to deserialize subscription update");
+        }
+        return new SubUpdate(l.getString(0), l.getString(1), l.getString(2), ts);
+    }
+
+}

--- a/src/main/java/org/iot/dsa/dslink/restadapter/SubscriptionRule.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/SubscriptionRule.java
@@ -1,7 +1,9 @@
 package org.iot.dsa.dslink.restadapter;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import javax.ws.rs.core.Response;
 import org.iot.dsa.DSRuntime;
 import org.iot.dsa.DSRuntime.Timer;
@@ -24,8 +26,10 @@ public class SubscriptionRule extends DSLogger implements OutboundSubscribeHandl
     private long lastUpdateTime = -1;
     private Timer future = null;
     private SubUpdate storedUpdate;
+    private boolean unsentInBuffer = false;
     
     private boolean valuesInBody = false;
+    private boolean batchable = false;
     private List<String> urlParamsWithValues = new ArrayList<String>();
     
     private String subPath;
@@ -74,9 +78,24 @@ public class SubscriptionRule extends DSLogger implements OutboundSubscribeHandl
                 }
             }
         }
+        int indexOfValue = body.indexOf(Constants.PLACEHOLDER_VALUE);
+        int indexOfTs = body.indexOf(Constants.PLACEHOLDER_TS);
+        int indexOfStatus = body.indexOf(Constants.PLACEHOLDER_STATUS);
         if (body != null) {
-            if (body.indexOf(Constants.PLACEHOLDER_VALUE) != -1 || body.indexOf(Constants.PLACEHOLDER_TS) != -1 || body.indexOf(Constants.PLACEHOLDER_STATUS) != -1) {
+            if (indexOfValue != -1 || indexOfTs != -1 || indexOfStatus != -1) {
                 valuesInBody = true;
+                int indexOfStart = body.indexOf(Constants.PLACEHOLDER_BLOCK_START);
+                int indexOfEnd = body.indexOf(Constants.PLACEHOLDER_BLOCK_END);
+                if (urlParamsWithValues.isEmpty() 
+                        && indexOfStart != -1 && indexOfEnd != -1 
+                        && (indexOfValue == -1 || indexOfStart < indexOfValue)
+                        && (indexOfTs == -1 || indexOfStart < indexOfTs)
+                        && (indexOfStatus == -1 || indexOfStart < indexOfStatus)
+                        && indexOfValue < indexOfEnd 
+                        && indexOfTs < indexOfEnd 
+                        && indexOfStatus < indexOfEnd) {
+                    batchable = true;
+                }
             }
         }
     }
@@ -102,47 +121,36 @@ public class SubscriptionRule extends DSLogger implements OutboundSubscribeHandl
     @Override
     public void onUpdate(DSDateTime dateTime, DSElement value, DSStatus status) {
         info("Rule with sub path " + subPath + ": onUpdate called with value " + (value!=null ? value : "Null"));
-        storedUpdate = new SubUpdate(dateTime, value, status);
+        storedUpdate = new SubUpdate(dateTime.toString(), value.toString(), status.toString(), dateTime.timeInMillis());
         if (lastUpdateTime < 0 || System.currentTimeMillis() - lastUpdateTime >= minRefreshRate) {
             if (future != null) {
                 future.cancel();
             }
-            sendUpdate(dateTime, value, status);
+            trySendUpdate(new SubUpdate(dateTime.toString(), value.toString(), status.toString(), dateTime.timeInMillis()));
         }
     }
     
     private void sendStoredUpdate() {
         if (storedUpdate != null) {
-            sendUpdate(storedUpdate.dateTime, storedUpdate.value, storedUpdate.status);
+            trySendUpdate(storedUpdate);
         }
     }
     
-    private void sendUpdate(final DSDateTime dateTime, final DSElement value, final DSStatus status) {
-        
-        DSMap urlParams = urlParameters.copy();
-        String body = this.body;
-        for (String key: urlParamsWithValues) {
-            String pattern = urlParams.getString(key);
-            if (Constants.PLACEHOLDER_VALUE.equals(pattern)) {
-                urlParams.put(key, value);
-            } else {
-                pattern = pattern.replaceAll(Constants.PLACEHOLDER_VALUE, value.toString());
-                pattern = pattern.replaceAll(Constants.PLACEHOLDER_TS, dateTime.toString());
-                pattern = pattern.replaceAll(Constants.PLACEHOLDER_STATUS, status.toString());
-                urlParams.put(key, pattern);
+    private String getSubId() {
+        return node.getId() + "_" + subPath;
+    }
+    
+    private void trySendUpdate(final SubUpdate update) {
+        if (sendUpdate(update)) {
+            if (unsentInBuffer) {
+                unsentInBuffer = !Util.processBuffer(getSubId(), this);
+            }
+        } else {
+            if (node.isBufferEnabled()) {
+                Util.storeInBuffer(getSubId(), update);
+                unsentInBuffer = true;
             }
         }
-        
-        if (valuesInBody) {
-            body = body.replaceAll(Constants.PLACEHOLDER_VALUE, value.toString());
-            body = body.replaceAll(Constants.PLACEHOLDER_TS, dateTime.toString());
-            body = body.replaceAll(Constants.PLACEHOLDER_STATUS, status.toString());
-        }
-        
-        info("Rule with sub path " + subPath + ": sending Update with value " + (value!=null ? value : "Null"));
-        
-        Response resp = getWebClientProxy().invoke(method, restUrl, urlParams, body);
-        node.responseRecieved(resp, rowNum);
         
         lastUpdateTime = System.currentTimeMillis();
         if (maxRefreshRate > 0) {
@@ -155,6 +163,91 @@ public class SubscriptionRule extends DSLogger implements OutboundSubscribeHandl
         }
     }
     
+    private boolean sendUpdate(final SubUpdate update) {
+        
+        DSMap urlParams = urlParameters.copy();
+        String body = this.body;
+        for (String key: urlParamsWithValues) {
+            String pattern = urlParams.getString(key);
+            if (Constants.PLACEHOLDER_VALUE.equals(pattern)) {
+                urlParams.put(key, update.value);
+            } else {
+                pattern = pattern.replaceAll(Constants.PLACEHOLDER_VALUE, update.value);
+                pattern = pattern.replaceAll(Constants.PLACEHOLDER_TS, update.dateTime);
+                pattern = pattern.replaceAll(Constants.PLACEHOLDER_STATUS, update.status);
+                urlParams.put(key, pattern);
+            }
+        }
+        
+        if (valuesInBody) {
+            body = body.replaceAll(Constants.PLACEHOLDER_VALUE, update.value);
+            body = body.replaceAll(Constants.PLACEHOLDER_TS, update.dateTime);
+            body = body.replaceAll(Constants.PLACEHOLDER_STATUS, update.status);
+            body = body.replaceAll(Constants.PLACEHOLDER_BLOCK_START, "");
+            body = body.replaceAll(Constants.PLACEHOLDER_BLOCK_END, "");
+        }
+        
+        info("Rule with sub path " + subPath + ": sending Update with value " + (update.value!=null ? update.value : "Null"));
+        
+        Response resp = restInvoke(urlParams, body);
+        return resp != null && resp.getStatus() == 200;
+    }
+    
+    public Queue<SubUpdate> sendBatchUpdate(Queue<SubUpdate> updates) {
+        if (!batchable) {
+            Queue<SubUpdate> failed = new LinkedList<SubUpdate>();
+            while (!updates.isEmpty()) {
+                SubUpdate update = updates.poll();
+                if (!sendUpdate(update)) {
+                    failed.add(update);
+                }
+            }
+            return failed;
+        }
+        DSMap urlParams = urlParameters.copy();
+        StringBuilder sb = new StringBuilder();
+        int indexOfStart = body.indexOf(Constants.PLACEHOLDER_BLOCK_START);
+        int indexOfEnd = body.indexOf(Constants.PLACEHOLDER_BLOCK_END);
+        String prefix = body.substring(0, indexOfStart);
+        String block = body.substring(indexOfStart + Constants.PLACEHOLDER_BLOCK_START.length(), indexOfEnd);
+        String suffix = body.substring(indexOfEnd + Constants.PLACEHOLDER_BLOCK_END.length());
+        sb.append(prefix);
+        Queue<SubUpdate> updatesCopy = new LinkedList<SubUpdate>();
+        while (!updates.isEmpty()) {
+            SubUpdate update = updates.poll();
+            updatesCopy.add(update);
+            String temp = block.replaceAll(Constants.PLACEHOLDER_VALUE, update.value)
+                    .replaceAll(Constants.PLACEHOLDER_TS, update.dateTime)
+                    .replaceAll(Constants.PLACEHOLDER_STATUS, update.status);
+            sb.append(temp);
+            if (!updates.isEmpty()) {
+                sb.append(',');
+            }
+        }
+        sb.append(suffix);
+        String body = sb.toString();
+        info("Rule with sub path " + subPath + ": sending batch update");
+        
+        Response resp = restInvoke(urlParams, body);
+        if (resp != null && resp.getStatus() == 200) {
+            return null;
+        } else {
+            return updatesCopy;
+        }
+        
+    }
+    
+    private Response restInvoke(DSMap urlParams, String body) {
+        Response resp = null;
+        try {
+            resp = getWebClientProxy().invoke(method, restUrl, urlParams, body);
+        } catch (Exception e) {
+            warn("", e);
+        }
+        node.responseRecieved(resp, rowNum);
+        return resp;
+    }
+    
     public void close() {
         if (stream != null && stream.isStreamOpen()) {
             info("Rule with sub path " + subPath + ": closing Stream");
@@ -162,21 +255,12 @@ public class SubscriptionRule extends DSLogger implements OutboundSubscribeHandl
         }
     }
     
+    public int getMaxBatchSize() {
+        return node.getMaxBatchSize();
+    }
 
     public WebClientProxy getWebClientProxy() {
         return node.getWebClientProxy();
-    }
-    
-    private static class SubUpdate {
-        final DSDateTime dateTime;
-        final DSElement value;
-        final DSStatus status;
-        
-        SubUpdate(DSDateTime dateTime, DSElement value, DSStatus status) {
-            this.dateTime = dateTime;
-            this.value = value;
-            this.status = status;
-        }
     }
 
 }

--- a/src/main/java/org/iot/dsa/dslink/restadapter/TestRuleNode.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/TestRuleNode.java
@@ -1,0 +1,96 @@
+package org.iot.dsa.dslink.restadapter;
+
+import org.iot.dsa.node.DSIObject;
+import org.iot.dsa.node.DSInfo;
+import org.iot.dsa.node.DSMap;
+import org.iot.dsa.node.DSNode;
+import org.iot.dsa.node.action.ActionInvocation;
+import org.iot.dsa.node.action.ActionResult;
+import org.iot.dsa.node.action.DSAction;
+
+public class TestRuleNode extends DSNode {
+    
+    private String subpath;
+    private TestSubscriptionRule rule;
+    
+    public TestRuleNode() {
+        
+    }
+
+    public TestRuleNode(String subpath) {
+        this.subpath = subpath;
+    }
+    
+    @Override
+    protected void declareDefaults() {
+        super.declareDefaults();
+        declareDefault(Constants.ACT_REMOVE, makeRemoveAction());
+        declareDefault("Refresh", makeRefreshAction());
+    }
+    
+    private DSIObject makeRefreshAction() {
+        return new DSAction() {
+            @Override
+            public ActionResult invoke(DSInfo info, ActionInvocation invocation) {
+                ((TestRuleNode) info.getParent()).refresh();
+                return null;
+            }
+
+            @Override
+            public void prepareParameter(DSInfo target, DSMap parameter) {
+                // TODO Auto-generated method stub
+                
+            }
+        };
+    }
+
+    protected void refresh() {
+        if (rule != null) {
+            rule.close();
+        }
+        onStable();
+    }
+
+    @Override
+    protected void onStarted() {
+        if (this.subpath == null) {
+            DSIObject o = get("SubPath");
+            if (o != null) {
+                this.subpath = o.toString();
+            }
+        } else {
+            put("SubPath", subpath).setHidden(true);
+        }
+    }
+    
+    @Override
+    protected void onStable() {
+        rule = new TestSubscriptionRule(this, subpath);
+//        put(Constants.ACT_EDIT, makeEditAction()).setTransient(true);
+    }
+    
+    private DSAction makeRemoveAction() {
+        return new DSAction() {
+            @Override
+            public ActionResult invoke(DSInfo info, ActionInvocation invocation) {
+                ((TestRuleNode) info.getParent()).delete();
+                return null;
+            }
+
+            @Override
+            public void prepareParameter(DSInfo target, DSMap parameter) {
+                // TODO Auto-generated method stub
+                
+            }
+        };
+    }
+
+    private void delete() {
+        if (rule != null) {
+            rule.close();
+        }
+        getParent().remove(getInfo());
+    }
+
+
+}

--- a/src/main/java/org/iot/dsa/dslink/restadapter/TestSubscriptionRule.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/TestSubscriptionRule.java
@@ -1,0 +1,69 @@
+package org.iot.dsa.dslink.restadapter;
+
+import org.iot.dsa.DSRuntime;
+import org.iot.dsa.dslink.DSIRequester;
+import org.iot.dsa.dslink.requester.ErrorType;
+import org.iot.dsa.dslink.requester.OutboundStream;
+import org.iot.dsa.dslink.requester.OutboundSubscribeHandler;
+import org.iot.dsa.logging.DSLogger;
+import org.iot.dsa.node.DSElement;
+import org.iot.dsa.node.DSStatus;
+import org.iot.dsa.time.DSDateTime;
+import org.iot.dsa.util.DSException;
+
+public class TestSubscriptionRule extends DSLogger implements OutboundSubscribeHandler {
+    
+    private String subpath;
+    private TestRuleNode node;
+    private OutboundStream stream;
+
+    public TestSubscriptionRule(TestRuleNode testRuleNode, String subpath) {
+        this.subpath = subpath;
+        this.node = testRuleNode;
+        DSRuntime.run(new Runnable() {
+            @Override
+            public void run() {
+                init();
+            }
+        });
+    }
+
+    protected void init() {
+        DSIRequester requester = MainNode.getRequester();
+        int qos = 0;
+        requester.subscribe(this.subpath, qos, this);
+        
+    }
+
+    @Override
+    public void onClose() {
+        info("Test Rule with sub path " + subpath + ": onClose called");
+        close();
+    }
+
+    @Override
+    public void onError(ErrorType type, String msg) {
+        info("Test Rule with sub path " + subpath + ": onError called with msg " + msg);
+        DSException.throwRuntime(new RuntimeException(msg));
+    }
+
+    @Override
+    public void onInit(String path, int qos, OutboundStream stream) {
+        info("Test Rule with sub path " + subpath + ": onInit called");
+        this.stream = stream; 
+    }
+
+    @Override
+    public void onUpdate(DSDateTime dateTime, DSElement value, DSStatus status) {
+        info("Test Rule with sub path " + subpath + ": onUpdate called with value " + (value!=null ? value : "Null"));
+        
+    }
+    
+    public void close() {
+        if (stream != null && stream.isStreamOpen()) {
+            info("Test Rule with sub path " + subpath + ": closing Stream");
+            stream.closeStream();
+        }
+    }
+
+}

--- a/src/main/java/org/iot/dsa/dslink/restadapter/Util.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/Util.java
@@ -1,11 +1,22 @@
 package org.iot.dsa.dslink.restadapter;
 
+import java.io.File;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+import org.etsdb.Database;
+import org.etsdb.DatabaseFactory;
+import org.etsdb.QueryCallback;
+import org.etsdb.util.DbPurger;
+import org.iot.dsa.DSRuntime;
 import org.iot.dsa.io.json.JsonReader;
 import org.iot.dsa.node.DSElement;
 import org.iot.dsa.node.DSList;
 import org.iot.dsa.node.DSMap;
 
 public class Util {
+    
+    private static Database<SubUpdate> buffer = null;
 
     enum AUTH_SCHEME {
         NO_AUTH,
@@ -67,5 +78,72 @@ public class Util {
                 return def;
             }
         }
+    }
+    
+    private static void initBuffer() {
+        File f = new File(Constants.BUFFER_PATH);
+        buffer = DatabaseFactory.createDatabase(f, new SubUpdateSerializer());
+        DbPurger purger = DbPurger.getInstance();
+        purger.addDb(buffer, MainNode.instance);
+        Runnable purgeRunner = purger.setupPurger();
+        DSRuntime.runAfterDelay(purgeRunner, 30000, 30000);
+    }
+    
+    public static void storeInBuffer(String subId, SubUpdate update) {
+        if (buffer == null) {
+            initBuffer();
+        }
+        buffer.write(subId, update.ts, update);
+    }
+    
+//    public static boolean isBufferEmpty(String subPath) {
+//        if (buffer == null) {
+//            return true;
+//        }
+//        buffer.get
+//        return true;
+//    }
+    
+    public static boolean processBuffer(String subId, SubscriptionRule subRule) {
+        if (buffer == null) {
+            return true;
+        }
+//        TimeRange range = buffer.getTimeRange(Collections.singletonList(subPath));
+//        if (range == null || range.isUndefined()) {
+//            return;
+//        }
+        final int maxBatchSize = subRule.getMaxBatchSize();
+        final LinkedList<SubUpdate> updates = new LinkedList<SubUpdate>();
+        final AtomicLong firstTs = new AtomicLong();
+        final AtomicLong lastTs = new AtomicLong();
+        int count;
+        do {
+            updates.clear();
+            buffer.query(subId, lastTs.get(), Long.MAX_VALUE, maxBatchSize, new QueryCallback<SubUpdate>() {
+                
+                @Override
+                public void sample(String seriesId, long ts, SubUpdate value) {
+                    updates.add(value);
+                    if (ts > lastTs.get()) {
+                        lastTs.set(ts);
+                    }
+                }
+            });
+            count = updates.size();
+            Queue<SubUpdate> failedUpdates = subRule.sendBatchUpdate(updates);
+            if (failedUpdates == null || failedUpdates.size() < count) {
+                buffer.delete(subId, firstTs.get(), lastTs.get());
+                firstTs.set(lastTs.get());
+                if (failedUpdates != null) {
+                    for (SubUpdate failedUpdate: failedUpdates) {
+                        storeInBuffer(subId, failedUpdate);
+                    }
+                }
+            } else {
+                return false;
+            }
+        } while (count >= maxBatchSize);
+        
+        return true;
     }
 }

--- a/src/main/java/org/iot/dsa/dslink/restadapter/WebClientProxy.java
+++ b/src/main/java/org/iot/dsa/dslink/restadapter/WebClientProxy.java
@@ -1,8 +1,6 @@
 package org.iot.dsa.dslink.restadapter;
 
 import org.apache.cxf.jaxrs.client.WebClient;
-import org.apache.cxf.rs.security.oauth2.client.OAuthClientUtils;
-import org.apache.cxf.rs.security.oauth2.common.ClientAccessToken;
 import org.iot.dsa.node.DSMap;
 import org.iot.dsa.node.DSMap.Entry;
 import org.iot.dsa.util.DSException;

--- a/src/test/java/org/iot/dsa/dslink/restadapter/SubUpdateSerializerTests.java
+++ b/src/test/java/org/iot/dsa/dslink/restadapter/SubUpdateSerializerTests.java
@@ -1,0 +1,28 @@
+package org.iot.dsa.dslink.restadapter;
+
+import org.junit.Test;
+import org.etsdb.ByteArrayBuilder;
+import org.iot.dsa.dslink.restadapter.SubUpdate;
+import org.iot.dsa.node.DSLong;
+import org.iot.dsa.node.DSStatus;
+import org.iot.dsa.time.DSDateTime;
+import static org.junit.Assert.*;
+
+public class SubUpdateSerializerTests {
+    
+    @Test
+    public void testSerializer() {
+        DSDateTime ts = DSDateTime.valueOf(2016, 10, 1);
+        SubUpdate before = new SubUpdate(ts, DSLong.valueOf(42), DSStatus.ok);
+        SubUpdateSerializer serializer = new SubUpdateSerializer();
+        ByteArrayBuilder builder = new ByteArrayBuilder();
+        serializer.toByteArray(builder, before, ts.timeInMillis());
+        SubUpdate after = serializer.fromByteArray(builder, ts.timeInMillis());
+        assertEquals(before.dateTime, after.dateTime);
+        assertEquals(before.value, after.value);
+        assertEquals(before.status, after.status);
+        assertEquals(before.ts, after.ts);
+    }
+    
+
+}

--- a/src/test/java/org/iot/dsa/dslink/restadapter/SubscriptionRuleTests.java
+++ b/src/test/java/org/iot/dsa/dslink/restadapter/SubscriptionRuleTests.java
@@ -1,0 +1,55 @@
+package org.iot.dsa.dslink.restadapter;
+
+import org.apache.cxf.jaxrs.impl.ResponseBuilderImpl;
+import org.iot.dsa.node.DSLong;
+import org.iot.dsa.node.DSMap;
+import org.iot.dsa.node.DSStatus;
+import org.iot.dsa.time.DSDateTime;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.TimeZone;
+
+public class SubscriptionRuleTests {
+    
+    String body = "Prefix_[%STARTBLOCK%{%TIMESTAMP%:%VALUE%}%ENDBLOCK%]_Suffix";
+    TimeZone utc = TimeZone.getTimeZone("UTC");
+    
+    @Test
+    public void testBatchSendSingular() {
+        TimeZone.setDefault(utc);
+        Queue<SubUpdate> updates = new LinkedList<SubUpdate>();
+        updates.add(new SubUpdate(DSDateTime.valueOf(2016, 10, 1, utc), DSLong.valueOf(42), DSStatus.ok));
+        String expectedBody = "Prefix_[{2016-10-01T00:00:00.000Z:42}]_Suffix";
+        testBatchSend(updates, expectedBody);
+    }
+    
+    @Test
+    public void testBatchSendPlural() {
+        Queue<SubUpdate> updates = new LinkedList<SubUpdate>();
+        updates.add(new SubUpdate(DSDateTime.valueOf(2016, 10, 1, utc), DSLong.valueOf(42), DSStatus.ok));
+        updates.add(new SubUpdate(DSDateTime.valueOf(2016, 10, 2, utc), DSLong.valueOf(43), DSStatus.ok));
+        updates.add(new SubUpdate(DSDateTime.valueOf(2016, 9, 2, utc), DSLong.valueOf(44), DSStatus.ok));
+        String expectedBody = "Prefix_[{2016-10-01T00:00:00.000Z:42},{2016-10-02T00:00:00.000Z:43},{2016-09-02T00:00:00.000Z:44}]_Suffix";
+        testBatchSend(updates, expectedBody);
+    }
+    
+    private void testBatchSend(Queue<SubUpdate> updates, String expectedBody) {
+//        MainNode.setRequester(requesterMock);
+        
+        WebClientProxy webClientProxy = mock(WebClientProxy.class);
+        when(webClientProxy.invoke(anyString(), anyString(), any(), anyString())).thenReturn(new ResponseBuilderImpl().status(200).build());
+        
+        AbstractRuleNode node = mock(AbstractRuleNode.class);
+        when(node.getWebClientProxy()).thenReturn(webClientProxy);
+        
+        SubscriptionRule sr = new SubscriptionRule(node, "/example", "example.com", "POST", new DSMap(), body, 0, 0, 0);
+        
+        assertNull(sr.sendBatchUpdate(updates));
+        
+        verify(webClientProxy).invoke("POST", "example.com", new DSMap(), expectedBody);
+    }
+
+}


### PR DESCRIPTION
Implement buffer feature, which uses an etsdb database to store updates that failed to send. Upon successfully sending an update, the DSLink will also send any unsent updates that are in the buffer. The buffer includes optional auto-purge functionality, which will erase the oldest unsent updates if the buffer exceeds a certain size. In order to more efficiently send the buffered updates, the rule format now includes %STARTBLOCK% and %ENDBLOCK% as delimeters for a repeatable block in a "batch update" request.